### PR TITLE
Refactor master bus API and transport layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,10 @@ end
 ```elixir
 alias EtherCAT.Bus.Transaction
 
-link = EtherCAT.link()
+bus = EtherCAT.bus()
 
 {:ok, result} =
-  EtherCAT.Bus.transaction(link, fn ->
+  EtherCAT.Bus.transaction(bus, fn ->
     Transaction.new()
     |> Transaction.fprd(station_addr, register, 2)    # read 2 bytes
     |> Transaction.fpwr(station_addr, register, data) # write data

--- a/lib/ethercat.ex
+++ b/lib/ethercat.ex
@@ -25,15 +25,19 @@ defmodule EtherCAT do
 
   ## Sub-modules
 
-  `EtherCAT.Slave`, `EtherCAT.Domain`, `EtherCAT.Link` — raw slave control,
+  `EtherCAT.Slave`, `EtherCAT.Domain`, `EtherCAT.Bus` — raw slave control,
   domain stats, and direct frame transactions.
   """
 
   alias EtherCAT.{Master, Slave}
 
-  @doc "Return the link pid for direct frame transactions."
+  @doc "Return the bus pid for direct frame transactions."
+  @spec bus() :: pid()
+  def bus, do: Master.bus()
+
+  @deprecated "Use bus/0 instead."
   @spec link() :: pid()
-  def link, do: Master.link()
+  def link, do: bus()
 
   @doc """
   Start the master: open the interface, scan for slaves, and begin
@@ -53,7 +57,7 @@ defmodule EtherCAT do
   @spec start(keyword()) :: :ok | {:error, term()}
   def start(opts \\ []), do: Master.start(opts)
 
-  @doc "Stop the master: shut down all slaves, domains, and the link."
+  @doc "Stop the master: shut down all slaves, domains, and the bus."
   @spec stop() :: :ok
   def stop, do: Master.stop()
 

--- a/lib/ethercat.ex
+++ b/lib/ethercat.ex
@@ -35,10 +35,6 @@ defmodule EtherCAT do
   @spec bus() :: pid()
   def bus, do: Master.bus()
 
-  @deprecated "Use bus/0 instead."
-  @spec link() :: pid()
-  def link, do: bus()
-
   @doc """
   Start the master: open the interface, scan for slaves, and begin
   self-driving configuration.

--- a/lib/ethercat/bus.ex
+++ b/lib/ethercat/bus.ex
@@ -91,8 +91,8 @@ defmodule EtherCAT.Bus do
 
     impl =
       if opts[:backup_interface],
-        do: EtherCAT.Bus.Redundant,
-        else: EtherCAT.Bus.SinglePort
+        do: EtherCAT.Bus.Transport.Redundant,
+        else: EtherCAT.Bus.Transport.SinglePort
 
     opts = Keyword.put(opts, :transport_mod, transport_mod)
 

--- a/lib/ethercat/bus/transport/redundant.ex
+++ b/lib/ethercat/bus/transport/redundant.ex
@@ -1,4 +1,4 @@
-defmodule EtherCAT.Bus.Redundant do
+defmodule EtherCAT.Bus.Transport.Redundant do
   @moduledoc """
   Dual-port redundant EtherCAT bus implementation.
 
@@ -16,7 +16,7 @@ defmodule EtherCAT.Bus.Redundant do
 
   ## Queue batching
 
-  Same as `Bus.SinglePort`: `Bus.transaction/3` calls are postponed when busy
+  Same as `Bus.Transport.SinglePort`: `Bus.transaction/3` calls are postponed when busy
   and expire if stale; `Bus.transaction_queue/2` calls always queue to pending.
   """
 

--- a/lib/ethercat/bus/transport/single_port.ex
+++ b/lib/ethercat/bus/transport/single_port.ex
@@ -1,4 +1,4 @@
-defmodule EtherCAT.Bus.SinglePort do
+defmodule EtherCAT.Bus.Transport.SinglePort do
   @moduledoc """
   Single-port EtherCAT bus implementation.
 
@@ -176,7 +176,7 @@ defmodule EtherCAT.Bus.SinglePort do
     n = length(data.awaiting_callers || [])
 
     Logger.warning(
-      "[Bus.SinglePort] frame timeout after #{elapsed_ms}ms — #{n} caller(s) lost (transport=#{data.transport_mod.name(data.transport)})"
+      "[Bus.Transport.SinglePort] frame timeout after #{elapsed_ms}ms — #{n} caller(s) lost (transport=#{data.transport_mod.name(data.transport)})"
     )
 
     data.transport_mod.drain(data.transport)

--- a/lib/ethercat/master.ex
+++ b/lib/ethercat/master.ex
@@ -98,10 +98,6 @@ defmodule EtherCAT.Master do
   @spec bus() :: pid() | nil
   def bus, do: :gen_statem.call(__MODULE__, :bus)
 
-  @deprecated "Use bus/0 instead."
-  @spec link() :: pid() | nil
-  def link, do: bus()
-
   @doc "Return the current master state atom."
   @spec state() :: atom()
   def state, do: :gen_statem.call(__MODULE__, :state)

--- a/lib/ethercat/master.ex
+++ b/lib/ethercat/master.ex
@@ -5,7 +5,7 @@ defmodule EtherCAT.Master do
   ## States
 
     - `:idle` — not started
-    - `:scanning` — link open, polling bus for a stable slave count
+    - `:scanning` — bus open, polling for a stable slave count
     - `:configuring` — stations assigned, DC initialised, slaves spawned;
       waiting for all named slaves to reach `:preop`
     - `:running` — fully operational
@@ -48,8 +48,8 @@ defmodule EtherCAT.Master do
   @configuring_timeout_ms 30_000
 
   defstruct [
-    :link_pid,
-    :link_ref,
+    :bus_pid,
+    :bus_ref,
     :dc_pid,
     # station address of the DC reference clock slave (nil if no DC)
     :dc_ref_station,
@@ -70,7 +70,7 @@ defmodule EtherCAT.Master do
   # -- Public API ------------------------------------------------------------
 
   @doc """
-  Start the master: open a link and begin scanning for slaves.
+  Start the master: open a bus and begin scanning for slaves.
 
   Options:
     - `:interface` (required) — e.g. `"eth0"`
@@ -86,7 +86,7 @@ defmodule EtherCAT.Master do
   @spec start(keyword()) :: :ok | {:error, term()}
   def start(opts \\ []), do: :gen_statem.call(__MODULE__, {:start, opts})
 
-  @doc "Stop the master: shut down all slaves, domains, and the link."
+  @doc "Stop the master: shut down all slaves, domains, and the bus."
   @spec stop() :: :ok
   def stop, do: :gen_statem.call(__MODULE__, :stop)
 
@@ -94,9 +94,13 @@ defmodule EtherCAT.Master do
   @spec slaves() :: list()
   def slaves, do: :gen_statem.call(__MODULE__, :slaves)
 
-  @doc "Return the link pid."
+  @doc "Return the bus pid."
+  @spec bus() :: pid() | nil
+  def bus, do: :gen_statem.call(__MODULE__, :bus)
+
+  @deprecated "Use bus/0 instead."
   @spec link() :: pid() | nil
-  def link, do: :gen_statem.call(__MODULE__, :link)
+  def link, do: bus()
 
   @doc "Return the current master state atom."
   @spec state() :: atom()
@@ -155,13 +159,13 @@ defmodule EtherCAT.Master do
            EtherCAT.SessionSupervisor,
            {Bus, interface: interface, name: EtherCAT.Bus}
          ) do
-      {:ok, link_pid} ->
-        link_ref = Process.monitor(link_pid)
+      {:ok, bus_pid} ->
+        bus_ref = Process.monitor(bus_pid)
 
         new_data = %{
           data
-          | link_pid: link_pid,
-            link_ref: link_ref,
+          | bus_pid: bus_pid,
+            bus_ref: bus_ref,
             base_station: base,
             slave_config: slave_config,
             domain_config: domain_config,
@@ -203,7 +207,7 @@ defmodule EtherCAT.Master do
     now_ms = System.monotonic_time(:millisecond)
 
     new_window =
-      case Bus.transaction_queue(data.link_pid, &Transaction.brd(&1, {0x0000, 1})) do
+      case Bus.transaction_queue(data.bus_pid, &Transaction.brd(&1, {0x0000, 1})) do
         {:ok, [%{wkc: n}]} ->
           # Prepend new reading; keep enough history to measure a full stable span
           window = [{now_ms, n} | data.scan_window]
@@ -306,8 +310,12 @@ defmodule EtherCAT.Master do
     {:keep_state_and_data, [{:reply, from, data.slaves}]}
   end
 
+  def handle_event({:call, from}, :bus, _state, data) do
+    {:keep_state_and_data, [{:reply, from, data.bus_pid}]}
+  end
+
   def handle_event({:call, from}, :link, _state, data) do
-    {:keep_state_and_data, [{:reply, from, data.link_pid}]}
+    {:keep_state_and_data, [{:reply, from, data.bus_pid}]}
   end
 
   # Catch-all for unrecognized calls in any active state
@@ -315,12 +323,12 @@ defmodule EtherCAT.Master do
     {:keep_state_and_data, [{:reply, from, {:error, state}}]}
   end
 
-  # Link crashed — clean up and return to idle
+  # Bus crashed — clean up and return to idle
   def handle_event(:info, {:DOWN, ref, :process, _pid, reason}, _state, data)
-      when ref == data.link_ref and not is_nil(ref) do
-    Logger.error("[Master] Link crashed (#{inspect(reason)}) — returning to idle")
+      when ref == data.bus_ref and not is_nil(ref) do
+    Logger.error("[Master] bus crashed (#{inspect(reason)}) — returning to idle")
     reply_await_callers(data.await_callers, {:error, {:link_down, reason}})
-    stop_session(%{data | link_pid: nil})
+    stop_session(%{data | bus_pid: nil})
     {:next_state, :idle, %__MODULE__{}}
   end
 
@@ -354,12 +362,12 @@ defmodule EtherCAT.Master do
 
   # -- Bus setup helpers -----------------------------------------------------
 
-  defp assign_stations(link, base, count) do
+  defp assign_stations(bus, base, count) do
     Enum.each(0..(count - 1), fn pos ->
       station = base + pos
 
       case Bus.transaction_queue(
-             link,
+             bus,
              &Transaction.apwr(&1, pos, Registers.station_address(station))
            ) do
         {:ok, [%{wkc: 1}]} ->
@@ -374,11 +382,11 @@ defmodule EtherCAT.Master do
     end)
   end
 
-  defp read_dl_status_all(link, base, count) do
+  defp read_dl_status_all(bus, base, count) do
     Enum.map(0..(count - 1), fn pos ->
       station = base + pos
 
-      case Bus.transaction_queue(link, &Transaction.fprd(&1, station, Registers.dl_status())) do
+      case Bus.transaction_queue(bus, &Transaction.fprd(&1, station, Registers.dl_status())) do
         {:ok, [%{data: status, wkc: 1}]} -> {station, status}
         _ -> {station, <<0, 0>>}
       end
@@ -402,14 +410,14 @@ defmodule EtherCAT.Master do
 
   defp normalize_slave_config(opts) when is_list(opts), do: opts
 
-  defp start_domains(link, domain_config) do
+  defp start_domains(bus, domain_config) do
     Enum.each(domain_config, fn entry ->
       domain_opts = normalize_domain_config(entry)
       id = Keyword.fetch!(domain_opts, :id)
 
       case DynamicSupervisor.start_child(
              EtherCAT.DomainSupervisor,
-             {Domain, [{:id, id}, {:link, link} | domain_opts]}
+             {Domain, [{:id, id}, {:link, bus} | domain_opts]}
            ) do
         {:ok, _pid} ->
           :ok
@@ -426,7 +434,7 @@ defmodule EtherCAT.Master do
   # Returns {:ok, slaves_list, named_slave_names}
   # slaves_list: [{name, station, pid}] for named slaves
   # named_slave_names: [name] — names to track in pending_preop
-  defp start_slaves(link, base, bus_count, slave_config, extra_opts) do
+  defp start_slaves(bus, base, bus_count, slave_config, extra_opts) do
     dc_cycle_ns = Keyword.get(extra_opts, :dc_cycle_ns)
 
     # Pad or trim config to match bus_count
@@ -454,7 +462,7 @@ defmodule EtherCAT.Master do
             domain = Keyword.get(slave_opts, :domain)
 
             opts = [
-              link: link,
+              link: bus,
               station: station,
               name: name,
               driver: driver,
@@ -490,19 +498,19 @@ defmodule EtherCAT.Master do
 
   # Runs synchronously in the scan handler before transitioning to :configuring/:running.
   defp do_configure(data) do
-    link = data.link_pid
+    bus = data.bus_pid
     count = data.slave_count
 
     Logger.info("[Master] configuring #{count} slave(s)")
 
-    assign_stations(link, data.base_station, count)
-    slave_stations = read_dl_status_all(link, data.base_station, count)
+    assign_stations(bus, data.base_station, count)
+    slave_stations = read_dl_status_all(bus, data.base_station, count)
 
     # DC hardware init (delays, offsets, PLL filter reset) before INIT→PREOP.
     # The DC gen_statem (cyclic ARMW) is started later in do_activate, after
     # all slaves reach PREOP, so its ticks don't compete with slave init.
     dc_ref_station =
-      case DC.init(link, slave_stations) do
+      case DC.init(bus, slave_stations) do
         {:ok, ref_station} ->
           Logger.info("[Master] DC initialized, ref=0x#{Integer.to_string(ref_station, 16)}")
           ref_station
@@ -514,10 +522,10 @@ defmodule EtherCAT.Master do
 
     # Start domains before slaves so domains are registered in the Registry
     # when slaves call Domain.register_pdo/4 in their :preop enter.
-    start_domains(link, data.domain_config || [])
+    start_domains(bus, data.domain_config || [])
 
     {:ok, slaves, named_slaves} =
-      start_slaves(link, data.base_station, count, data.slave_config || [],
+      start_slaves(bus, data.base_station, count, data.slave_config || [],
         dc_cycle_ns: if(dc_ref_station, do: data.dc_cycle_ns, else: nil)
       )
 
@@ -539,7 +547,7 @@ defmodule EtherCAT.Master do
       if data.dc_ref_station do
         case DynamicSupervisor.start_child(
                EtherCAT.SessionSupervisor,
-               {DC, link: data.link_pid, ref_station: data.dc_ref_station, period_ms: 10}
+               {DC, link: data.bus_pid, ref_station: data.dc_ref_station, period_ms: 10}
              ) do
           {:ok, pid} ->
             pid
@@ -599,8 +607,8 @@ defmodule EtherCAT.Master do
       DynamicSupervisor.terminate_child(EtherCAT.SlaveSupervisor, pid)
     end)
 
-    if data.link_pid do
-      DynamicSupervisor.terminate_child(EtherCAT.SessionSupervisor, data.link_pid)
+    if data.bus_pid do
+      DynamicSupervisor.terminate_child(EtherCAT.SessionSupervisor, data.bus_pid)
     end
   end
 

--- a/lib/ethercat/master.md
+++ b/lib/ethercat/master.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 `EtherCAT.Master` is the singleton `gen_statem` registered as `EtherCAT.Master` (local name).
-It coordinates the entire bus startup sequence: link open, slave count stabilization, station
+It coordinates the entire bus startup sequence: bus open, slave count stabilization, station
 assignment, DC initialization, slave spawning, and transition to operational state.
 
 Supervised as `:permanent` under `EtherCAT.Application`. Started at application boot, not
@@ -21,7 +21,7 @@ restarted on individual slave crashes.
 | State | Description |
 |-------|-------------|
 | `:idle` | Not started. Rejects all calls except `start/1`. |
-| `:scanning` | Link open, polling bus for a stable slave count via BRD to `0x0000`. |
+| `:scanning` | Bus open, polling for a stable slave count via BRD to `0x0000`. |
 | `:configuring` | Stations assigned, DC initialized, slaves spawned. Waiting for all named slaves to send `{:slave_ready, name, :preop}`. |
 | `:running` | All slaves at `:preop`, domains cycling, slaves advanced to `:op`. Stable operational state. |
 
@@ -32,7 +32,7 @@ restarted on individual slave crashes.
 Entry action: immediately schedule `{:timeout, :scan_poll}` with 0 ms delay.
 
 On each scan poll:
-1. `Bus.transaction_queue(link, &Transaction.brd(&1, {0x0000, 1}))` — BRD to register 0 (any accessible byte). WKC = number of responding slaves.
+1. `Bus.transaction_queue(bus, &Transaction.brd(&1, {0x0000, 1}))` — BRD to register 0 (any accessible byte). WKC = number of responding slaves.
 2. Append `{monotonic_ms, wkc}` to sliding window; trim entries older than `scan_stable_ms + scan_poll_ms` (1100 ms window).
 3. Stable when: window spans ≥ 1000 ms, ≥ 2 readings, all readings identical, count > 0.
 4. On stability: call `do_configure/1` synchronously, then transition to `:configuring` or `:running` (the latter if no named slaves).
@@ -51,7 +51,7 @@ APWR to each slave by auto-increment position (0 to count-1), writing `base_stat
 FPRD `0x0110–0x0111` from each slave — 2-byte DL status. Passed to `DC.init/2` to determine topology (which ports are open).
 
 **Step 3: DC initialization**
-`DC.init(link, slave_stations)` — see DC section below. Returns `{:ok, ref_station}` or `{:error, reason}`.
+`DC.init(bus, slave_stations)` — see DC section below. Returns `{:ok, ref_station}` or `{:error, reason}`.
 
 If DC init fails, master proceeds without DC: `dc_cycle_ns` is set to `nil`, no SYNC0 will be configured on any slave.
 
@@ -82,7 +82,7 @@ When `pending_preop` empties: call `do_activate/1` and transition to `:running`.
 Runs synchronously before transitioning to `:running`.
 
 **Step 1: Start DC gen_statem**
-`DC.start_link(link: link, ref_station: ref_station, period_ms: 10)` — starts cyclic ARMW ticker.
+`DC.start_link(link: bus, ref_station: ref_station, period_ms: 10)` — starts cyclic ARMW ticker.
 Started *after* all slaves reach `:preop` so DC ticks don't compete with slave SM transitions on the socket.
 
 **Step 2: Start domain cycling**
@@ -98,9 +98,9 @@ Started *after* all slaves reach `:preop` so DC ticks don't compete with slave S
 
 ## Running Phase
 
-Master accepts `stop/0`, `slaves/0`, `link/0`, `state/0`, and `await_running/1`.
+Master accepts `stop/0`, `slaves/0`, `bus/0`, `state/0`, and `await_running/1`.
 Ignores `{:slave_ready, ...}` (stale from restart race).
-On link crash (`{:DOWN, ref, ...}`): calls `stop_session/1`, replies `{:error, {:link_down, reason}}` to blocked callers, returns to `:idle`.
+On bus crash (`{:DOWN, ref, ...}`): calls `stop_session/1`, replies `{:error, {:link_down, reason}}` to blocked callers, returns to `:idle`.
 
 ---
 
@@ -124,7 +124,7 @@ Implements ESC datasheet §9.1.3.6 (clock synchronization initialization):
 
 `DC` is a `gen_statem` in state `:running`. On each tick (default 10 ms):
 ```
-Bus.transaction(link, &Transaction.armw(&1, ref_station, Registers.dc_system_time()))
+Bus.transaction(bus, &Transaction.armw(&1, ref_station, Registers.dc_system_time()))
 ```
 ARMW to `0x0910` of reference clock: the reference clock's 64-bit system time is read into the datagram; all downstream slaves in the ring write the datagram value to their own `0x0910`. Each slave's PLL computes `Δt` and adjusts clock speed.
 
@@ -138,8 +138,8 @@ Telemetry: `[:ethercat, :dc, :tick]` with `%{wkc: wkc}` on each tick.
 
 ```elixir
 %EtherCAT.Master{
-  link_pid:        pid() | nil,
-  link_ref:        reference() | nil,    # Process.monitor ref for link crash detection
+  bus_pid:         pid() | nil,
+  bus_ref:         reference() | nil,    # Process.monitor ref for bus crash detection
   dc_pid:          pid() | nil,          # DC gen_statem pid
   dc_ref_station:  non_neg_integer() | nil,  # Station of reference clock slave
   slave_config:    list(),               # Raw slave config entries from start/1
@@ -158,7 +158,7 @@ Telemetry: `[:ethercat, :dc, :tick]` with `%{wkc: wkc}` on each tick.
 
 ## Known Gaps
 
-- **No per-slave monitoring after Op**: master does not poll AL status or error counters on running slaves. Slave crashes are not detected by the master (only link crashes trigger recovery).
+- **No per-slave monitoring after Op**: master does not poll AL status or error counters on running slaves. Slave crashes are not detected by the master (only bus crashes trigger recovery).
 - **Sequential slave activation**: slaves are advanced to SafeOp then Op one at a time via synchronous `Slave.request/2`. For large slave counts this can be slow. Parallel advancement (async + barrier) is not implemented.
 - **No DC lock detection**: master does not wait for DC PLL to lock (read `0x092C` converging to 0) before advancing slaves to Op. Slaves enter Op before clocks are fully synchronized.
 - **No static drift pre-compensation**: the datasheet recommends sending ~15,000 ARMW frames before operation to eliminate static drift. The DC gen_statem starts periodic ticking immediately without this warm-up phase.

--- a/lib/ethercat/telemetry.ex
+++ b/lib/ethercat/telemetry.ex
@@ -101,7 +101,7 @@ defmodule EtherCAT.Telemetry do
   end
 
   # ---------------------------------------------------------------------------
-  # Convenience emitters — called from Bus.SinglePort and Bus.Redundant
+  # Convenience emitters — called from Bus.Transport.SinglePort and Bus.Transport.Redundant
   # ---------------------------------------------------------------------------
 
   @doc false


### PR DESCRIPTION
# Summary

Completes the master refactor away from legacy `link` naming by using `bus` terminology throughout the public master-facing API, and keeps the bus runtime modules organized under `EtherCAT.Bus.Transport.*`.

## Changes

- Renamed master runtime state and query paths from `link_*` naming to `bus_*` naming.
- Moved runtime transport implementations to `EtherCAT.Bus.Transport.SinglePort` and `EtherCAT.Bus.Transport.Redundant` and updated `EtherCAT.Bus.start_link/1` wiring.
- Removed deprecated public compatibility shims `EtherCAT.link/0` and `EtherCAT.Master.link/0`.
- Updated docs/examples to use `bus` naming for direct transaction access.

## Motivation

Implements Linear ticket https://linear.app/sid2baker/issue/SID-16/refactor-master-module and GitHub issue https://github.com/sid2baker/ethercat/issues/2 to eliminate legacy naming and simplify the master/bus module surface.

## Validation

- [x] `mix compile --warnings-as-errors`
- [x] `mix test`

## Notes

This is an intentional pre-release API break: callers must use `EtherCAT.bus/0` instead of `EtherCAT.link/0`.
