### PR TITLE
Make EtherCAT.start configs explicit and dynamic

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,8 +50,10 @@ Master :scanning ──── BRD 0x0000, count stable ──── Master :conf
               │
               preop enter: sdo_config → register_pdos_and_fmmus → {:slave_ready, name, :preop}
               │
-              Master collects all {:slave_ready} → DC start → domain cycling →
-              Slave.request(:safeop) → Slave.request(:op) → Master :running
+              Master collects all {:slave_ready} →
+              (explicit config) DC start → domain cycling → SafeOp → Op
+              OR (dynamic startup) remain in PreOp for runtime configuration →
+              Master :running
 ```
 
 ### Cyclic I/O (Domain owns)
@@ -118,10 +120,10 @@ calls `{:next_state, ...}`.
 3. `Domain.start_link` per config — creates ETS tables, enters `:open`
 4. `Slave.start_link` per config — starts SII read, mailbox SM config, auto-advances to `:preop`
 5. `Master` waits for all `{:slave_ready, name, :preop}` messages (30 s timeout)
-6. `DC.start_link` — starts ARMW ticker (after all slaves are in PreOp)
-7. `Domain.start_cycling` per domain — begins self-timed LRW
-8. `Slave.request(:safeop)` per slave — configures DC SYNC signals (SYNC0 activation)
-9. `Slave.request(:op)` per slave — full process data exchange active
+6. If activatable slaves exist: `DC.start_link` — starts ARMW ticker (after all slaves are in PreOp)
+7. If activatable slaves exist: `Domain.start_cycling` per domain — begins self-timed LRW
+8. If activatable slaves exist: `Slave.request(:safeop)` per slave — configures DC SYNC signals (SYNC0 activation)
+9. If activatable slaves exist: `Slave.request(:op)` per slave — full process data exchange active
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ sudo setcap cap_net_raw+ep _build/dev/lib/ethercat/priv/raw_socket
 EtherCAT.start(
   interface: "enp0s31f6",
   slaves: [
+    %EtherCAT.Slave.Config{name: :coupler},
     %EtherCAT.Slave.Config{name: :el1809, driver: MyApp.EL1809Driver},
     %EtherCAT.Slave.Config{name: :el2809, driver: MyApp.EL2809Driver}
   ],

--- a/examples/el3202.exs
+++ b/examples/el3202.exs
@@ -61,9 +61,9 @@ EtherCAT.start(
   interface: interface,
   domains: [[id: :main, period: 10]],
   slaves: [
-    nil,
-    nil,
-    nil,
+    [name: :coupler],
+    [name: :bridge_1],
+    [name: :bridge_2],
     [name: :thermo, driver: El3202Driver, config: %{}, pdos: [channel1: :main, channel2: :main]]
   ]
 )

--- a/examples/hardware_test.exs
+++ b/examples/hardware_test.exs
@@ -2,7 +2,7 @@
 # EtherCAT hardware stress test — new EtherCAT top-level API
 #
 # Hardware setup (3-slave ring):
-#   position 0 → 0x1000  EK1100 coupler  (nil — no driver)
+#   position 0 → 0x1000  EK1100 coupler  (default driver)
 #   position 1 → 0x1001  EL1809 16-ch digital input
 #   position 2 → 0x1002  EL2809 16-ch digital output
 #   position 3 → 0x1003  EL3202 2-ch PT100 resistance input
@@ -317,7 +317,7 @@ check.("EtherCAT.start", EtherCAT.start(
     %EtherCAT.Domain.Config{id: :main, period: period_ms, miss_threshold: 500}
   ],
   slaves: [
-    nil,
+    %EtherCAT.Slave.Config{name: :coupler},
     %EtherCAT.Slave.Config{name: :sensor, driver: Example.EL1809, domain: :main},
     %EtherCAT.Slave.Config{name: :valve,  driver: Example.EL2809, domain: :main},
     %EtherCAT.Slave.Config{name: :thermo, driver: Example.EL3202, domain: :main}

--- a/examples/loopback.exs
+++ b/examples/loopback.exs
@@ -45,7 +45,12 @@ Process.sleep(300)
 :ok = EtherCAT.start(
   interface: interface,
   domains: [[id: :main, period: 4]],
-  slaves: [nil, nil, [name: :out, driver: DigitalOut, config: %{}, pdos: [ch1: :main]], nil]
+  slaves: [
+    [name: :coupler],
+    [name: :bridge_1],
+    [name: :out, driver: DigitalOut, config: %{}, pdos: [ch1: :main]],
+    [name: :bridge_3]
+  ]
 )
 :ok = EtherCAT.await_running(10_000)
 

--- a/examples/sdo_debug.exs
+++ b/examples/sdo_debug.exs
@@ -22,7 +22,12 @@ Process.sleep(300)
 EtherCAT.start(
   interface: interface,
   domains: [],
-  slaves: [nil, nil, nil, [name: :thermo, driver: nil, config: %{}, pdos: []]]
+  slaves: [
+    [name: :coupler],
+    [name: :bridge_1],
+    [name: :bridge_2],
+    [name: :thermo, config: %{}, pdos: []]
+  ]
 )
 
 # Allow auto-advance (SII read + mailbox SM setup + PREOP transition) to complete

--- a/lib/ethercat.ex
+++ b/lib/ethercat.ex
@@ -10,7 +10,7 @@ defmodule EtherCAT do
           %EtherCAT.Domain.Config{id: :main, period: 1}
         ],
         slaves: [
-          nil,
+          %EtherCAT.Slave.Config{name: :coupler},
           %EtherCAT.Slave.Config{name: :sensor, driver: MyApp.EL1809, domain: :main},
           %EtherCAT.Slave.Config{name: :valve,  driver: MyApp.EL2809, domain: :main}
         ]
@@ -45,8 +45,11 @@ defmodule EtherCAT do
   Options:
     - `:interface` (required) — network interface, e.g. `"eth0"`
     - `:domains` — list of `%EtherCAT.Domain.Config{}` structs
-    - `:slaves` — list of `%EtherCAT.Slave.Config{}` structs or `nil`
-      (position matters — station address = `base_station + index`)
+    - `:slaves` — list of `%EtherCAT.Slave.Config{}` structs
+      (position matters — station address = `base_station + index`).
+      `nil` entries are rejected; use `%EtherCAT.Slave.Config{name: :coupler}` for
+      unnamed couplers. If omitted or empty, one default slave process is started
+      per discovered station and held in `:preop` for dynamic configuration.
     - `:base_station` — first station address, default `0x1000`
     - `:dc_cycle_ns` — SYNC0 cycle time in ns, default `1_000_000`
     - `:frame_timeout_ms` — optional fixed bus frame response timeout in ms

--- a/lib/ethercat/master.ex
+++ b/lib/ethercat/master.ex
@@ -19,7 +19,7 @@ defmodule EtherCAT.Master do
         interface: "eth0",
         domains: [%EtherCAT.Domain.Config{id: :main, period: 1}],
         slaves: [
-          nil,
+          %EtherCAT.Slave.Config{name: :coupler},
           %EtherCAT.Slave.Config{name: :sensor, driver: MyApp.EL1809, domain: :main},
           %EtherCAT.Slave.Config{name: :valve,  driver: MyApp.EL2809, domain: :main}
         ]
@@ -27,7 +27,8 @@ defmodule EtherCAT.Master do
       :ok = EtherCAT.await_running()
 
   Station addresses are assigned from list position: `base_station + index`.
-  `nil` entries get a station address but no Slave gen_statem is started.
+  When `slaves: []` (or omitted), the master starts one dynamic default slave per
+  discovered station and leaves them in `:preop` for runtime configuration.
   """
 
   @behaviour :gen_statem
@@ -36,6 +37,7 @@ defmodule EtherCAT.Master do
 
   alias EtherCAT.{DC, Domain, Bus, Slave}
   alias EtherCAT.Bus.Transaction
+  alias EtherCAT.Slave.Driver.Default, as: DefaultSlaveDriver
   alias EtherCAT.Slave.Registers
 
   @base_station 0x1000
@@ -67,6 +69,7 @@ defmodule EtherCAT.Master do
     :dc_cycle_ns,
     :frame_timeout_override_ms,
     base_station: @base_station,
+    activatable_slaves: [],
     slaves: [],
     # [{monotonic_ms, count}] — sliding window for scan stability
     scan_window: [],
@@ -84,10 +87,12 @@ defmodule EtherCAT.Master do
 
   Options:
     - `:interface` (required) — e.g. `"eth0"`
-    - `:slaves` — list of slave config entries, default `[]`. Each entry is either `nil`
-      (station assigned, no driver) or a keyword list with keys: `:name`, `:driver`,
+    - `:slaves` — list of slave config entries, default `[]`. Each entry is a
+      `%EtherCAT.Slave.Config{}` (or equivalent keyword list) with keys: `:name`, `:driver`,
       `:config`, and `:pdos` (`[{pdo_name, domain_id}]` pairs — passed to the slave
-      which self-registers in its `:preop` enter handler)
+      which self-registers in its `:preop` enter handler). `nil` entries are rejected.
+      If omitted, dynamic default slaves are started for all discovered stations and
+      held in `:preop` for runtime configuration.
     - `:domains` — list of domain specs, default `[]`. Each entry is a keyword list with
       keys `:id` (atom, required) and `:period` (ms, required), plus any Domain options
     - `:base_station` — starting station address, default `0x1000`
@@ -164,32 +169,38 @@ defmodule EtherCAT.Master do
     dc_cycle_ns = Keyword.get(opts, :dc_cycle_ns, 1_000_000)
     frame_timeout_override_ms = Keyword.get(opts, :frame_timeout_ms)
 
-    bus_opts =
-      [interface: interface, name: EtherCAT.Bus]
-      |> maybe_put_frame_timeout(frame_timeout_override_ms)
+    with :ok <- validate_slave_start_config(slave_config) do
+      bus_opts =
+        [interface: interface, name: EtherCAT.Bus]
+        |> maybe_put_frame_timeout(frame_timeout_override_ms)
 
-    case DynamicSupervisor.start_child(
-           EtherCAT.SessionSupervisor,
-           {Bus, bus_opts}
-         ) do
-      {:ok, bus_pid} ->
-        bus_ref = Process.monitor(bus_pid)
+      case DynamicSupervisor.start_child(
+             EtherCAT.SessionSupervisor,
+             {Bus, bus_opts}
+           ) do
+        {:ok, bus_pid} ->
+          bus_ref = Process.monitor(bus_pid)
 
-        new_data = %{
-          data
-          | bus_pid: bus_pid,
-            bus_ref: bus_ref,
-            base_station: base,
-            slave_config: slave_config,
-            domain_config: domain_config,
-            dc_cycle_ns: dc_cycle_ns,
-            frame_timeout_override_ms: frame_timeout_override_ms,
-            slaves: [],
-            scan_window: []
-        }
+          new_data = %{
+            data
+            | bus_pid: bus_pid,
+              bus_ref: bus_ref,
+              base_station: base,
+              slave_config: slave_config,
+              domain_config: domain_config,
+              dc_cycle_ns: dc_cycle_ns,
+              frame_timeout_override_ms: frame_timeout_override_ms,
+              activatable_slaves: [],
+              slaves: [],
+              scan_window: []
+          }
 
-        {:next_state, :scanning, new_data, [{:reply, from, :ok}]}
+          {:next_state, :scanning, new_data, [{:reply, from, :ok}]}
 
+        {:error, _} = err ->
+          {:keep_state_and_data, [{:reply, from, err}]}
+      end
+    else
       {:error, _} = err ->
         {:keep_state_and_data, [{:reply, from, err}]}
     end
@@ -408,6 +419,18 @@ defmodule EtherCAT.Master do
     end)
   end
 
+  defp validate_slave_start_config(slave_config) when is_list(slave_config) do
+    case Enum.find_index(slave_config, &is_nil/1) do
+      nil ->
+        :ok
+
+      idx ->
+        {:error, {:invalid_slave_config, {:nil_entry, idx}}}
+    end
+  end
+
+  defp validate_slave_start_config(_), do: {:error, {:invalid_slave_config, :invalid_list}}
+
   defp normalize_domain_config(%EtherCAT.Domain.Config{} = cfg) do
     [
       id: cfg.id,
@@ -420,10 +443,47 @@ defmodule EtherCAT.Master do
   defp normalize_domain_config(opts) when is_list(opts), do: opts
 
   defp normalize_slave_config(%EtherCAT.Slave.Config{} = cfg) do
-    [name: cfg.name, driver: cfg.driver, config: cfg.config, domain: cfg.domain, pdos: cfg.pdos]
+    [
+      name: cfg.name,
+      driver: normalize_slave_driver(cfg.driver),
+      config: cfg.config,
+      domain: cfg.domain,
+      pdos: cfg.pdos,
+      auto_activate?: true
+    ]
   end
 
-  defp normalize_slave_config(opts) when is_list(opts), do: opts
+  defp normalize_slave_config(opts) when is_list(opts) do
+    [
+      name: Keyword.fetch!(opts, :name),
+      driver: normalize_slave_driver(Keyword.get(opts, :driver)),
+      config: Keyword.get(opts, :config, %{}),
+      domain: Keyword.get(opts, :domain),
+      pdos: Keyword.get(opts, :pdos, []),
+      auto_activate?: Keyword.get(opts, :auto_activate?, true)
+    ]
+  end
+
+  defp normalize_slave_driver(nil), do: DefaultSlaveDriver
+  defp normalize_slave_driver(driver), do: driver
+
+  defp dynamic_slave_configs(0), do: []
+
+  defp dynamic_slave_configs(bus_count) do
+    Enum.map(0..(bus_count - 1), fn pos ->
+      [
+        name: dynamic_slave_name(pos),
+        driver: DefaultSlaveDriver,
+        config: %{},
+        domain: nil,
+        pdos: [],
+        auto_activate?: false
+      ]
+    end)
+  end
+
+  defp dynamic_slave_name(0), do: :coupler
+  defp dynamic_slave_name(pos), do: :"slave_#{pos}"
 
   defp maybe_put_frame_timeout(opts, timeout_ms) when is_integer(timeout_ms) and timeout_ms > 0 do
     Keyword.put(opts, :frame_timeout_ms, timeout_ms)
@@ -504,28 +564,22 @@ defmodule EtherCAT.Master do
     end)
   end
 
-  # Returns {:ok, slaves_list, named_slave_names}
+  # Returns {:ok, slaves_list, pending_preop_names, activatable_names}
   # slaves_list: [{name, station, pid}] for named slaves
-  # named_slave_names: [name] — names to track in pending_preop
+  # pending_preop_names: [name] — names to track in pending_preop
+  # activatable_names: [name] — names the master should move PREOP→OP
   defp start_slaves(bus, base, bus_count, slave_config, extra_opts) do
     dc_cycle_ns = Keyword.get(extra_opts, :dc_cycle_ns)
+    effective_config = if(slave_config == [], do: dynamic_slave_configs(bus_count), else: [])
 
-    # Pad or trim config to match bus_count
-    config_padded =
-      slave_config
-      |> Enum.take(bus_count)
-      |> then(fn c -> c ++ List.duplicate(nil, max(0, bus_count - length(c))) end)
-
-    {slaves, named_names} =
-      config_padded
+    {slaves, pending_names, activatable_names} =
+      effective_config
+      |> Kernel.++(Enum.take(slave_config, bus_count))
       |> Enum.with_index()
-      |> Enum.reduce({[], []}, fn {entry, pos}, {slave_acc, names_acc} ->
+      |> Enum.reduce({[], [], []}, fn {entry, pos}, {slave_acc, pending_acc, activatable_acc} ->
         station = base + pos
 
         case entry do
-          nil ->
-            {slave_acc, names_acc}
-
           entry when is_list(entry) or is_struct(entry, EtherCAT.Slave.Config) ->
             slave_opts = normalize_slave_config(entry)
             name = Keyword.fetch!(slave_opts, :name)
@@ -533,6 +587,7 @@ defmodule EtherCAT.Master do
             config = Keyword.get(slave_opts, :config, %{})
             pdos = Keyword.get(slave_opts, :pdos, [])
             domain = Keyword.get(slave_opts, :domain)
+            auto_activate? = Keyword.get(slave_opts, :auto_activate?, true)
 
             opts = [
               link: bus,
@@ -547,19 +602,33 @@ defmodule EtherCAT.Master do
 
             case DynamicSupervisor.start_child(EtherCAT.SlaveSupervisor, {Slave, opts}) do
               {:ok, pid} ->
-                {[{name, station, pid} | slave_acc], [name | names_acc]}
+                activatable_acc =
+                  if auto_activate? do
+                    [name | activatable_acc]
+                  else
+                    activatable_acc
+                  end
+
+                {[{name, station, pid} | slave_acc], [name | pending_acc], activatable_acc}
 
               {:error, reason} ->
                 Logger.error(
                   "[Master] failed to start slave #{inspect(name)} at 0x#{Integer.to_string(station, 16)}: #{inspect(reason)}"
                 )
 
-                {slave_acc, names_acc}
+                {slave_acc, pending_acc, activatable_acc}
             end
+
+          invalid_entry ->
+            Logger.warning(
+              "[Master] invalid slave config at position #{pos}: #{inspect(invalid_entry)}"
+            )
+
+            {slave_acc, pending_acc, activatable_acc}
         end
       end)
 
-    {:ok, Enum.reverse(slaves), named_names}
+    {:ok, Enum.reverse(slaves), Enum.reverse(pending_names), Enum.reverse(activatable_names)}
   end
 
   defp get_domain_ids(domain_config) do
@@ -597,7 +666,7 @@ defmodule EtherCAT.Master do
     # when slaves call Domain.register_pdo/4 in their :preop enter.
     start_domains(bus, data.domain_config || [])
 
-    {:ok, slaves, named_slaves} =
+    {:ok, slaves, pending_preop, activatable_slaves} =
       start_slaves(bus, data.base_station, count, data.slave_config || [],
         dc_cycle_ns: if(dc_ref_station, do: data.dc_cycle_ns, else: nil)
       )
@@ -606,11 +675,17 @@ defmodule EtherCAT.Master do
       data
       | dc_ref_station: dc_ref_station,
         slaves: slaves,
-        pending_preop: MapSet.new(named_slaves)
+        pending_preop: MapSet.new(pending_preop),
+        activatable_slaves: activatable_slaves
     }
   end
 
   # Runs synchronously in the scan/configuring handler before transitioning to :running.
+  defp do_activate(%{activatable_slaves: []} = data) do
+    Logger.info("[Master] dynamic startup: slaves held in :preop for runtime configuration")
+    data
+  end
+
   defp do_activate(data) do
     Logger.info("[Master] activating — starting DC, domains, and advancing slaves to :op")
 
@@ -645,7 +720,7 @@ defmodule EtherCAT.Master do
       end
     end)
 
-    Enum.each(data.slaves, fn {name, _station, _pid} ->
+    Enum.each(data.activatable_slaves, fn name ->
       case Slave.request(name, :safeop) do
         :ok ->
           :ok
@@ -655,7 +730,7 @@ defmodule EtherCAT.Master do
       end
     end)
 
-    Enum.each(data.slaves, fn {name, _station, _pid} ->
+    Enum.each(data.activatable_slaves, fn name ->
       case Slave.request(name, :op) do
         :ok ->
           :ok

--- a/lib/ethercat/master.md
+++ b/lib/ethercat/master.md
@@ -23,7 +23,7 @@ restarted on individual slave crashes.
 | `:idle` | Not started. Rejects all calls except `start/1`. |
 | `:scanning` | Bus open, polling for a stable slave count via BRD to `0x0000`. |
 | `:configuring` | Stations assigned, DC initialized, slaves spawned. Waiting for all named slaves to send `{:slave_ready, name, :preop}`. |
-| `:running` | All slaves at `:preop`, domains cycling, slaves advanced to `:op`. Stable operational state. |
+| `:running` | Startup sequence complete. Explicitly configured slaves are advanced to `:op`; dynamic defaults may remain in `:preop` for runtime configuration. |
 
 ---
 
@@ -59,7 +59,9 @@ If DC init fails, master proceeds without DC: `dc_cycle_ns` is set to `nil`, no 
 `start_domains/2` starts one `EtherCAT.Domain` gen_statem per domain config entry via `EtherCAT.DomainSupervisor`. Domains must exist before slaves call `Domain.register_pdo/4` in their `:preop` enter handler. Each domain registers itself in `EtherCAT.Registry` under `{:domain, id}`.
 
 **Step 5: Start slaves**
-`start_slaves/5` — one `EtherCAT.Slave` gen_statem per config entry via `EtherCAT.SlaveSupervisor`. `nil` config entries receive a station address but no gen_statem. Named slaves are tracked in `pending_preop` MapSet.
+`start_slaves/5` — one `EtherCAT.Slave` gen_statem per config entry via `EtherCAT.SlaveSupervisor`. `nil` config entries are rejected at `start/1`. Missing drivers use `EtherCAT.Slave.Driver.Default`.
+
+If `slaves: []` (or omitted), the master auto-creates one default slave config per discovered station (`:coupler`, `:slave_1`, ...), starts all of them, and tracks them in `pending_preop` so each process still executes INIT→PREOP.
 
 Slaves receive `dc_cycle_ns` only if DC init succeeded (otherwise `nil`).
 
@@ -80,6 +82,8 @@ When `pending_preop` empties: call `do_activate/1` and transition to `:running`.
 ## Activation (`do_activate/1`)
 
 Runs synchronously before transitioning to `:running`.
+
+If no activatable slaves are configured (dynamic startup mode), activation is skipped and slaves remain in `:preop`.
 
 **Step 1: Start DC gen_statem**
 `DC.start_link(link: bus, ref_station: ref_station, period_ms: 10)` — starts cyclic ARMW ticker.
@@ -148,6 +152,7 @@ Telemetry: `[:ethercat, :dc, :tick]` with `%{wkc: wkc}` on each tick.
   frame_timeout_override_ms: pos_integer() | nil, # Optional fixed bus frame timeout
   base_station:    non_neg_integer(),    # Default 0x1000
   slaves:          [{name, station, pid}], # Named slave tuples
+  activatable_slaves: [atom()],          # Slaves to auto-advance PREOP→OP
   scan_window:     [{ms, count}],        # Sliding stability window
   slave_count:     non_neg_integer() | nil,
   pending_preop:   MapSet.t(),           # Names not yet reporting :preop

--- a/lib/ethercat/slave.ex
+++ b/lib/ethercat/slave.ex
@@ -4,21 +4,20 @@ defmodule EtherCAT.Slave.Config do
 
   Fields:
     - `:name` (required) — atom identifying this slave
-    - `:driver` (required) — module implementing `EtherCAT.Slave.Driver`
+    - `:driver` — module implementing `EtherCAT.Slave.Driver`,
+      defaults to `EtherCAT.Slave.Driver.Default`
     - `:config` — driver-specific configuration map, default `%{}`
     - `:domain` — when set (and `:pdos` is empty), all PDO names from the
       driver's `process_data_profile/1` are auto-registered against this domain id
     - `:pdos` — explicit `[{pdo_name, domain_id}]` override list; when non-empty,
       `:domain` is ignored and this list is used verbatim
   """
-  @enforce_keys [:name, :driver]
-  defstruct [
-    :name,
-    :driver,
-    :domain,
-    config: %{},
-    pdos: []
-  ]
+  @enforce_keys [:name]
+  defstruct name: nil,
+            driver: EtherCAT.Slave.Driver.Default,
+            domain: nil,
+            config: %{},
+            pdos: []
 end
 
 defmodule EtherCAT.Slave do
@@ -204,7 +203,7 @@ defmodule EtherCAT.Slave do
     link = Keyword.fetch!(opts, :link)
     station = Keyword.fetch!(opts, :station)
     name = Keyword.fetch!(opts, :name)
-    driver = Keyword.get(opts, :driver)
+    driver = Keyword.get(opts, :driver, EtherCAT.Slave.Driver.Default)
     config = Keyword.get(opts, :config, %{})
     dc_cycle_ns = Keyword.get(opts, :dc_cycle_ns)
     pdos = Keyword.get(opts, :pdos, [])

--- a/lib/ethercat/slave.md
+++ b/lib/ethercat/slave.md
@@ -72,7 +72,7 @@ via the `@paths` map. `walk_path/2` calls `do_transition/2` for each intermediat
   link:              pid(),              # Bus server reference
   station:           non_neg_integer(),  # Configured station address (e.g. 0x1000)
   name:              atom(),             # Slave name atom
-  driver:            module() | nil,     # Module implementing EtherCAT.Slave.Driver
+  driver:            module(),           # Module implementing EtherCAT.Slave.Driver (default: EtherCAT.Slave.Driver.Default)
   config:            map(),              # Driver-specific config, passed to all callbacks
   domain:            atom() | nil,       # Default domain id for auto-PDO-registration
   error_code:        non_neg_integer() | nil,  # Last AL status code from ESC

--- a/lib/ethercat/slave/driver.ex
+++ b/lib/ethercat/slave/driver.ex
@@ -5,6 +5,10 @@ defmodule EtherCAT.Slave.Driver do
   A driver is a pure module — no process state, no `Application.get_env`.
   All configuration is passed as a `config` map from `Master.start/1`.
 
+  If a slave config omits `:driver`, `EtherCAT.Slave.Driver.Default` is used.
+  That default driver exposes no PDO profile and is intended for couplers or
+  dynamically configured devices.
+
   ## Profile format
 
   `process_data_profile/1` returns a map keyed by PDO name (atom) with values

--- a/lib/ethercat/slave/driver/default.ex
+++ b/lib/ethercat/slave/driver/default.ex
@@ -1,0 +1,19 @@
+defmodule EtherCAT.Slave.Driver.Default do
+  @moduledoc """
+  Fallback driver used when a slave is named without a specific hardware driver.
+
+  This driver intentionally exposes no PDO profile. It allows a slave process
+  to complete INIT→PREOP so hardware can be configured dynamically at runtime.
+  """
+
+  @behaviour EtherCAT.Slave.Driver
+
+  @impl true
+  def process_data_profile(_config), do: %{}
+
+  @impl true
+  def encode_outputs(_pdo_name, _config, _value), do: <<>>
+
+  @impl true
+  def decode_inputs(_pdo_name, _config, raw), do: raw
+end

--- a/test/ethercat_test.exs
+++ b/test/ethercat_test.exs
@@ -1,6 +1,31 @@
 defmodule EtherCATTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
-  # Placeholder — the previous test referenced a nonexistent EtherCAT.Driver module.
-  # Integration tests require hardware and are run via examples/diag.exs and examples/io_quick.exs.
+  setup do
+    _ = EtherCAT.stop()
+    :ok
+  end
+
+  test "start rejects nil slave placeholders" do
+    assert {:error, {:invalid_slave_config, {:nil_entry, 1}}} =
+             EtherCAT.start(
+               interface: "eth0",
+               slaves: [%EtherCAT.Slave.Config{name: :coupler}, nil]
+             )
+
+    assert EtherCAT.state() == :idle
+  end
+
+  test "slave config defaults to the built-in default driver" do
+    cfg = %EtherCAT.Slave.Config{name: :coupler}
+    assert cfg.driver == EtherCAT.Slave.Driver.Default
+  end
+
+  test "default slave driver is a safe no-op profile" do
+    driver = EtherCAT.Slave.Driver.Default
+
+    assert driver.process_data_profile(%{}) == %{}
+    assert driver.encode_outputs(:unused, %{}, 1) == <<>>
+    assert driver.decode_inputs(:unused, %{}, <<0xAB, 0xCD>>) == <<0xAB, 0xCD>>
+  end
 end

--- a/test/telemetry_test.exs
+++ b/test/telemetry_test.exs
@@ -44,7 +44,8 @@ defmodule EtherCAT.TelemetryTest do
 
     Telemetry.domain_cycle_done(:main, 42, 7)
 
-    assert_receive {:telemetry_event, ^event_name, %{duration_us: 42, cycle_count: 7}, %{domain: :main}}
+    assert_receive {:telemetry_event, ^event_name, %{duration_us: 42, cycle_count: 7},
+                    %{domain: :main}}
   end
 
   test "domain_cycle_missed/3 emits the domain missed telemetry event" do
@@ -66,7 +67,8 @@ defmodule EtherCAT.TelemetryTest do
 
     Telemetry.domain_cycle_missed(:main, 3, :no_response)
 
-    assert_receive {:telemetry_event, ^event_name, %{miss_count: 3}, %{domain: :main, reason: :no_response}}
+    assert_receive {:telemetry_event, ^event_name, %{miss_count: 3},
+                    %{domain: :main, reason: :no_response}}
   end
 
   def handle_event(event, measurements, metadata, pid) do


### PR DESCRIPTION
# Summary

Makes the public EtherCAT startup API explicit and dynamic: `nil` slave placeholders are rejected, missing drivers now default to a built-in no-op driver, and starting with no hardware config auto-discovers slaves and keeps them in PREOP for runtime configuration.

## Changes

- Added `EtherCAT.Slave.Driver.Default` and made `%EtherCAT.Slave.Config{}` require only `:name` with default `driver`.
- Updated `EtherCAT.Master.start/1` to reject `nil` entries in `:slaves` at API boundary.
- Normalized missing/`nil` drivers to the default driver during master config handling.
- Added dynamic startup mode: when `:slaves` is omitted/empty, start one slave process per discovered station (`:coupler`, `:slave_N`) and hold them in PREOP.
- Added activation gating so only explicitly configured slaves auto-transition to SAFEOP/OP; dynamic defaults remain PREOP.
- Updated public docs/examples/context docs to remove `nil` placeholders and document explicit coupler/default-driver usage.
- Added tests for nil-placeholder rejection and default-driver behavior.

## Motivation

Implements [SID-18](https://linear.app/sid2baker/issue/SID-18/make-public-ethercat-module-api-more-dynamic):
- disallow `nil` placeholders in `EtherCAT.start/1` slave config,
- support explicit coupler entries with default driver fallback,
- allow startup without hardware config while still bringing discovered slaves to PREOP for dynamic runtime configuration.

## Validation

- [x] `mix compile --warnings-as-errors`
- [x] `mix test`

## Notes

Dynamic startup intentionally skips automatic DC/domain/slave activation and leaves discovered default slaves in PREOP. This aligns with INIT→PREOP sequencing from the local EtherCAT spec docs and keeps runtime configuration possible before SAFEOP/OP transitions.
