### PR TITLE
SID-20: fix input readiness and clean up bus naming

### DIFF
--- a/lib/ethercat/dc.ex
+++ b/lib/ethercat/dc.ex
@@ -50,13 +50,13 @@ defmodule EtherCAT.DC do
   """
   @spec initialize_clocks(Bus.server(), [{non_neg_integer(), binary()}]) ::
           {:ok, non_neg_integer()} | {:error, term()}
-  def initialize_clocks(link, slave_stations) when slave_stations != [] do
+  def initialize_clocks(bus, slave_stations) when slave_stations != [] do
     stations = Enum.map(slave_stations, &elem(&1, 0))
 
     # Step 1: trigger receive-time latch on all slaves
-    with :ok <- trigger_recv_latch(link),
+    with :ok <- trigger_recv_latch(bus),
          # Step 2: read receive times from every slave
-         {:ok, recv_times} <- read_recv_times(link, stations),
+         {:ok, recv_times} <- read_recv_times(bus, stations),
          # Step 3: identify reference clock
          {:ok, ref_idx} <- find_ref_clock(recv_times),
          ref_station = Enum.at(stations, ref_idx) do
@@ -64,15 +64,15 @@ defmodule EtherCAT.DC do
 
       # Step 4: calculate propagation delays and write to each slave
       delays = calc_delays(recv_times, slave_stations)
-      write_delays(link, stations, delays)
+      write_delays(bus, stations, delays)
 
       # Step 5: write system time offsets
       master_ns = System.os_time(:nanosecond) - @ethercat_epoch_offset_ns
       {ref_ecat_ns, _, _} = Enum.at(recv_times, ref_idx)
-      write_offsets(link, stations, recv_times, ref_idx, ref_ecat_ns, master_ns)
+      write_offsets(bus, stations, recv_times, ref_idx, ref_ecat_ns, master_ns)
 
       # Step 6: reset PLL filters on all DC-capable slaves
-      reset_filters(link, stations, recv_times)
+      reset_filters(bus, stations, recv_times)
 
       # Step 7: static drift pre-compensation is done by the DC gen_statem
       # on startup so it runs concurrently with slave init and SII reads.
@@ -98,7 +98,7 @@ defmodule EtherCAT.DC do
   Start the DC drift maintenance gen_statem.
 
   Options:
-    - `:link` (required) — Link server reference
+    - `:bus` (required) — Bus server reference
     - `:ref_station` (required) — station address of the reference clock
     - `:period_ms` — drift correction interval, default 10 ms
   """
@@ -114,11 +114,11 @@ defmodule EtherCAT.DC do
 
   @impl true
   def init(opts) do
-    link = Keyword.fetch!(opts, :link)
+    bus = Keyword.fetch!(opts, :bus)
     ref_station = Keyword.fetch!(opts, :ref_station)
     period_ms = Keyword.get(opts, :period_ms, 10)
 
-    data = %{link: link, ref_station: ref_station, period_ms: period_ms, fail_count: 0}
+    data = %{bus: bus, ref_station: ref_station, period_ms: period_ms, fail_count: 0}
     {:ok, :running, data}
   end
 
@@ -132,7 +132,7 @@ defmodule EtherCAT.DC do
   def handle_event(:state_timeout, :tick, :running, data) do
     result =
       Bus.transaction(
-        data.link,
+        data.bus,
         &Transaction.armw(&1, data.ref_station, Registers.dc_system_time()),
         drift_tick_timeout_us(data.period_ms)
       )
@@ -165,19 +165,19 @@ defmodule EtherCAT.DC do
 
   # -- Init helpers ----------------------------------------------------------
 
-  defp trigger_recv_latch(link) do
-    case Bus.transaction_queue(link, &Transaction.bwr(&1, Registers.dc_recv_time_latch())) do
+  defp trigger_recv_latch(bus) do
+    case Bus.transaction_queue(bus, &Transaction.bwr(&1, Registers.dc_recv_time_latch())) do
       {:ok, _} -> :ok
       {:error, _} = err -> err
     end
   end
 
-  defp read_recv_times(link, stations) do
+  defp read_recv_times(bus, stations) do
     results =
       Enum.map(stations, fn station ->
         ecat =
           case Bus.transaction_queue(
-                 link,
+                 bus,
                  &Transaction.fprd(&1, station, Registers.dc_recv_time_ecat())
                ) do
             {:ok, [%{data: <<t::64-little>>, wkc: 1}]} -> t
@@ -186,7 +186,7 @@ defmodule EtherCAT.DC do
 
         p0 =
           case Bus.transaction_queue(
-                 link,
+                 bus,
                  &Transaction.fprd(&1, station, Registers.dc_recv_time(0))
                ) do
             {:ok, [%{data: <<t::32-little>>, wkc: 1}]} -> t
@@ -195,7 +195,7 @@ defmodule EtherCAT.DC do
 
         p1 =
           case Bus.transaction_queue(
-                 link,
+                 bus,
                  &Transaction.fprd(&1, station, Registers.dc_recv_time(1))
                ) do
             {:ok, [%{data: <<t::32-little>>, wkc: 1}]} -> t
@@ -238,14 +238,14 @@ defmodule EtherCAT.DC do
     |> Enum.reverse()
   end
 
-  defp write_delays(link, stations, delays) do
+  defp write_delays(bus, stations, delays) do
     Enum.zip(stations, delays)
     |> Enum.each(fn {station, delay} ->
-      link_tx(link, &Transaction.fpwr(&1, station, Registers.dc_system_time_delay(delay)))
+      bus_tx(bus, &Transaction.fpwr(&1, station, Registers.dc_system_time_delay(delay)))
     end)
   end
 
-  defp write_offsets(link, stations, recv_times, ref_idx, ref_ecat_ns, master_ns) do
+  defp write_offsets(bus, stations, recv_times, ref_idx, ref_ecat_ns, master_ns) do
     ref_offset = master_ns - ref_ecat_ns
 
     Enum.zip(stations, recv_times)
@@ -259,26 +259,26 @@ defmodule EtherCAT.DC do
             ref_ecat_ns - ecat_ns + ref_offset
           end
 
-        link_tx(link, &Transaction.fpwr(&1, station, Registers.dc_system_time_offset(offset)))
+        bus_tx(bus, &Transaction.fpwr(&1, station, Registers.dc_system_time_offset(offset)))
       end
     end)
   end
 
-  defp reset_filters(link, stations, recv_times) do
+  defp reset_filters(bus, stations, recv_times) do
     Enum.zip(stations, recv_times)
     |> Enum.each(fn {station, {ecat_ns, _, _}} ->
       if ecat_ns != nil do
         # Read current value and write it back — this resets the filter
         case Bus.transaction_queue(
-               link,
+               bus,
                &Transaction.fprd(&1, station, Registers.dc_speed_counter_start())
              ) do
           {:ok, [%{data: <<v::16-little>>, wkc: 1}]} ->
-            link_tx(link, &Transaction.fpwr(&1, station, Registers.dc_speed_counter_start(v)))
+            bus_tx(bus, &Transaction.fpwr(&1, station, Registers.dc_speed_counter_start(v)))
 
           _ ->
-            link_tx(
-              link,
+            bus_tx(
+              bus,
               &Transaction.fpwr(&1, station, Registers.dc_speed_counter_start(0x1000))
             )
         end
@@ -287,8 +287,8 @@ defmodule EtherCAT.DC do
   end
 
   # Thin wrapper — ignore result (init writes may get no wkc if slaves not yet ready)
-  defp link_tx(link, fun) do
-    Bus.transaction_queue(link, fun)
+  defp bus_tx(bus, fun) do
+    Bus.transaction_queue(bus, fun)
   end
 
   defp drift_tick_timeout_us(period_ms) when is_integer(period_ms) and period_ms > 0 do

--- a/lib/ethercat/domain.ex
+++ b/lib/ethercat/domain.ex
@@ -60,7 +60,7 @@ defmodule EtherCAT.Domain do
 
   defstruct [
     :id,
-    :link,
+    :bus,
     :period_us,
     :logical_base,
     :next_cycle_at,
@@ -99,7 +99,7 @@ defmodule EtherCAT.Domain do
 
   Options:
     - `:id` (required) — atom, also ETS table name and Registry key
-    - `:link` (required) — Link pid
+    - `:bus` (required) — bus pid
     - `:period` (required) — cycle period in milliseconds
     - `:logical_base` — LRW logical address base, default `0`
     - `:miss_threshold` — stop after N consecutive misses, default `100`
@@ -183,7 +183,7 @@ defmodule EtherCAT.Domain do
   @impl true
   def init(opts) do
     id = Keyword.fetch!(opts, :id)
-    link = Keyword.fetch!(opts, :link)
+    bus = Keyword.fetch!(opts, :bus)
     period_ms = Keyword.fetch!(opts, :period)
     logical_base = Keyword.get(opts, :logical_base, 0)
     miss_threshold = Keyword.get(opts, :miss_threshold, 100)
@@ -201,7 +201,7 @@ defmodule EtherCAT.Domain do
 
     data = %__MODULE__{
       id: id,
-      link: link,
+      bus: bus,
       period_us: period_ms * 1000,
       logical_base: logical_base,
       next_cycle_at: nil,
@@ -306,7 +306,7 @@ defmodule EtherCAT.Domain do
 
     result =
       Bus.transaction(
-        data.link,
+        data.bus,
         &Transaction.lrw(&1, {data.logical_base, image}),
         cycle_transaction_timeout_us(data.period_us)
       )

--- a/lib/ethercat/domain.md
+++ b/lib/ethercat/domain.md
@@ -114,7 +114,7 @@ record     : {key, value, slave_pid}
 ```elixir
 %EtherCAT.Domain{
   id:               atom(),              # Domain ID; also ETS table name
-  link:             pid(),               # Bus server reference
+  bus:              pid(),               # Bus server reference
   period_us:        pos_integer(),       # Cycle period in microseconds
   logical_base:     non_neg_integer(),   # LRW logical address base (default 0)
   next_cycle_at:    integer() | nil,     # Monotonic target time for next tick

--- a/lib/ethercat/master.ex
+++ b/lib/ethercat/master.ex
@@ -67,7 +67,6 @@ defmodule EtherCAT.Master do
     # station address of the DC reference clock slave (nil if no DC)
     :dc_ref_station,
     :domain_config,
-    :domain_pids,
     :slave_config,
     :dc_cycle_ns,
     :frame_timeout_override_ms,
@@ -198,7 +197,6 @@ defmodule EtherCAT.Master do
               activatable_slaves: [],
               slaves: [],
               scan_window: [],
-              domain_pids: [],
               activation_failures: %{}
           }
 
@@ -390,10 +388,6 @@ defmodule EtherCAT.Master do
     {:keep_state_and_data, [{:reply, from, data.bus_pid}]}
   end
 
-  def handle_event({:call, from}, :link, _state, data) do
-    {:keep_state_and_data, [{:reply, from, data.bus_pid}]}
-  end
-
   # Catch-all for unrecognized calls in any active state
   def handle_event({:call, from}, _event, state, _data) do
     {:keep_state_and_data, [{:reply, from, {:error, state}}]}
@@ -403,7 +397,7 @@ defmodule EtherCAT.Master do
   def handle_event(:info, {:DOWN, ref, :process, _pid, reason}, _state, data)
       when ref == data.bus_ref and not is_nil(ref) do
     Logger.error("[Master] bus crashed (#{inspect(reason)}) — returning to idle")
-    reply_await_callers(data.await_callers, {:error, {:link_down, reason}})
+    reply_await_callers(data.await_callers, {:error, {:bus_down, reason}})
     stop_session(%{data | bus_pid: nil})
     {:next_state, :idle, %__MODULE__{}}
   end
@@ -594,28 +588,26 @@ defmodule EtherCAT.Master do
   end
 
   defp start_domains(bus, domain_config) do
-    domain_config
-    |> Enum.reduce([], fn entry, acc ->
+    Enum.each(domain_config, fn entry ->
       domain_opts = normalize_domain_config(entry)
       id = Keyword.fetch!(domain_opts, :id)
 
       case DynamicSupervisor.start_child(
              EtherCAT.SessionSupervisor,
-             {Domain, [{:id, id}, {:link, bus} | domain_opts]}
+             {Domain, [{:id, id}, {:bus, bus} | domain_opts]}
            ) do
-        {:ok, pid} ->
-          [pid | acc]
+        {:ok, _pid} ->
+          :ok
 
-        {:error, {:already_started, pid}} ->
+        {:error, {:already_started, _pid}} ->
           Logger.warning("[Master] domain #{inspect(id)} already started")
-          [pid | acc]
+          :ok
 
         {:error, reason} ->
           Logger.error("[Master] failed to start domain #{inspect(id)}: #{inspect(reason)}")
-          acc
+          :ok
       end
     end)
-    |> Enum.reverse()
   end
 
   # Returns {:ok, slaves_list, pending_preop_names, activatable_names}
@@ -644,7 +636,7 @@ defmodule EtherCAT.Master do
             auto_activate? = Keyword.get(slave_opts, :auto_activate?, true)
 
             opts = [
-              link: bus,
+              bus: bus,
               station: station,
               name: name,
               driver: driver,
@@ -718,7 +710,7 @@ defmodule EtherCAT.Master do
 
     # Start domains before slaves so domains are registered in the Registry
     # when slaves call Domain.register_pdo/4 in their :preop enter.
-    domain_pids = start_domains(bus, data.domain_config || [])
+    start_domains(bus, data.domain_config || [])
 
     {:ok, slaves, pending_preop, activatable_slaves} =
       start_slaves(bus, data.base_station, count, data.slave_config || [],
@@ -731,7 +723,6 @@ defmodule EtherCAT.Master do
         slaves: slaves,
         pending_preop: MapSet.new(pending_preop),
         activatable_slaves: activatable_slaves,
-        domain_pids: domain_pids,
         activation_failures: %{}
     }
   end
@@ -751,7 +742,7 @@ defmodule EtherCAT.Master do
       if data.dc_ref_station do
         case DynamicSupervisor.start_child(
                EtherCAT.SessionSupervisor,
-               {DC, link: data.bus_pid, ref_station: data.dc_ref_station, period_ms: 10}
+               {DC, bus: data.bus_pid, ref_station: data.dc_ref_station, period_ms: 10}
              ) do
           {:ok, pid} ->
             pid
@@ -802,8 +793,8 @@ defmodule EtherCAT.Master do
       DynamicSupervisor.terminate_child(EtherCAT.SlaveSupervisor, pid)
     end)
 
-    Enum.each(data.domain_pids || [], fn pid ->
-      DynamicSupervisor.terminate_child(EtherCAT.SessionSupervisor, pid)
+    Enum.each(get_domain_ids(data.domain_config || []), fn domain_id ->
+      terminate_domain(domain_id)
     end)
 
     if data.bus_pid do
@@ -862,5 +853,15 @@ defmodule EtherCAT.Master do
 
   defp reply_await_callers(callers, reply) do
     Enum.each(callers, fn from -> :gen_statem.reply(from, reply) end)
+  end
+
+  defp terminate_domain(domain_id) do
+    case Registry.lookup(EtherCAT.Registry, {:domain, domain_id}) do
+      [{pid, _}] ->
+        DynamicSupervisor.terminate_child(EtherCAT.SessionSupervisor, pid)
+
+      [] ->
+        :ok
+    end
   end
 end

--- a/lib/ethercat/master.md
+++ b/lib/ethercat/master.md
@@ -87,7 +87,7 @@ Runs synchronously before transitioning to `:running`.
 If no activatable slaves are configured (dynamic startup mode), activation is skipped and slaves remain in `:preop`.
 
 **Step 1: Start DC gen_statem**
-`DC.start_link(link: bus, ref_station: ref_station, period_ms: 10)` — starts cyclic ARMW ticker.
+`DC.start_link(bus: bus, ref_station: ref_station, period_ms: 10)` — starts cyclic ARMW ticker.
 Started *after* all slaves reach `:preop` so DC ticks don't compete with slave SM transitions on the socket.
 
 **Step 2: Start domain cycling**
@@ -107,7 +107,7 @@ If any activatable slave fails SafeOp/Op, master enters `:degraded` and retries 
 
 Master accepts `stop/0`, `slaves/0`, `bus/0`, `state/0`, and `await_running/1`.
 Ignores `{:slave_ready, ...}` (stale from restart race).
-On bus crash (`{:DOWN, ref, ...}`): calls `stop_session/1`, replies `{:error, {:link_down, reason}}` to blocked callers, returns to `:idle`.
+On bus crash (`{:DOWN, ref, ...}`): calls `stop_session/1`, replies `{:error, {:bus_down, reason}}` to blocked callers, returns to `:idle`.
 
 ## Degraded Phase
 
@@ -158,7 +158,6 @@ Telemetry: `[:ethercat, :dc, :tick]` with `%{wkc: wkc}` on each tick.
   dc_ref_station:  non_neg_integer() | nil,  # Station of reference clock slave
   slave_config:    list(),               # Raw slave config entries from start/1
   domain_config:   list(),               # Raw domain config entries from start/1
-  domain_pids:     [pid()],              # Session-scoped Domain processes
   dc_cycle_ns:     pos_integer() | nil,  # SYNC0 period; nil if no DC
   frame_timeout_override_ms: pos_integer() | nil, # Optional fixed bus frame timeout
   base_station:    non_neg_integer(),    # Default 0x1000

--- a/lib/ethercat/slave.ex
+++ b/lib/ethercat/slave.ex
@@ -85,7 +85,7 @@ defmodule EtherCAT.Slave do
   @poll_interval_ms 1
 
   defstruct [
-    :link,
+    :bus,
     :station,
     :name,
     :driver,
@@ -200,7 +200,7 @@ defmodule EtherCAT.Slave do
 
   @impl true
   def init(opts) do
-    link = Keyword.fetch!(opts, :link)
+    bus = Keyword.fetch!(opts, :bus)
     station = Keyword.fetch!(opts, :station)
     name = Keyword.fetch!(opts, :name)
     driver = Keyword.get(opts, :driver, EtherCAT.Slave.Driver.Default)
@@ -213,7 +213,7 @@ defmodule EtherCAT.Slave do
     Registry.register(EtherCAT.Registry, {:slave_station, station}, name)
 
     data = %__MODULE__{
-      link: link,
+      bus: bus,
       station: station,
       name: name,
       driver: driver,
@@ -418,7 +418,7 @@ defmodule EtherCAT.Slave do
   def handle_event(:state_timeout, :latch_poll, :op, data) do
     if data.active_latches do
       case Bus.transaction(
-             data.link,
+             data.bus,
              fn tx ->
                Transaction.fprd(tx, data.station, Registers.dc_latch_event_status())
              end,
@@ -473,7 +473,7 @@ defmodule EtherCAT.Slave do
       "[Slave #{data.name}] init: reading SII (station=0x#{Integer.to_string(data.station, 16)})"
     )
 
-    case read_sii(data.link, data.station) do
+    case read_sii(data.bus, data.station) do
       {:ok, identity, mailbox_config, sm_configs, pdo_configs} ->
         sii_ms = System.monotonic_time(:millisecond) - t0
 
@@ -612,7 +612,7 @@ defmodule EtherCAT.Slave do
             # SM register: full SM size, byte-aligned. Keep SM deactivated while reprogramming.
             sm_reg = <<phys::16-little, total_sm_size::16-little, ctrl::8, 0::8, 0x00::8, 0::8>>
 
-            case Bus.transaction_queue(data.link, fn tx ->
+            case Bus.transaction_queue(data.bus, fn tx ->
                    tx
                    |> Transaction.fpwr(data.station, Registers.sm_activate(sm_idx, 0))
                    |> Transaction.fpwr(data.station, Registers.sm(sm_idx, sm_reg))
@@ -625,12 +625,12 @@ defmodule EtherCAT.Slave do
                       0::8, fmmu_type::8, 0x01::8, 0::24>>
 
                   case Bus.transaction_queue(
-                         data.link,
+                         data.bus,
                          &Transaction.fpwr(&1, data.station, Registers.fmmu(fmmu_idx, fmmu_reg))
                        ) do
                     {:ok, [%{wkc: wkc}]} when wkc > 0 ->
                       case Bus.transaction_queue(
-                             data.link,
+                             data.bus,
                              &Transaction.fpwr(&1, data.station, Registers.sm_activate(sm_idx, 1))
                            ) do
                         {:ok, [%{wkc: activate_wkc}]} when activate_wkc > 0 ->
@@ -696,7 +696,7 @@ defmodule EtherCAT.Slave do
 
     with {:ok, [%{wkc: wkc}]} when wkc > 0 <-
            Bus.transaction_queue(
-             data.link,
+             data.bus,
              &Transaction.fpwr(&1, data.station, Registers.al_control(code))
            ) do
       poll_al(data, code, @poll_limit)
@@ -715,7 +715,7 @@ defmodule EtherCAT.Slave do
 
   defp poll_al(data, code, n) do
     case Bus.transaction_queue(
-           data.link,
+           data.bus,
            &Transaction.fprd(&1, data.station, Registers.al_status())
          ) do
       {:ok, [%{data: <<_::3, _err::1, state::4, _::8>>, wkc: wkc}]}
@@ -741,7 +741,7 @@ defmodule EtherCAT.Slave do
   defp ack_error(data) do
     err_code =
       case Bus.transaction_queue(
-             data.link,
+             data.bus,
              &Transaction.fprd(&1, data.station, Registers.al_status_code())
            ) do
         {:ok, [%{data: <<c::16-little>>, wkc: wkc}]} when wkc > 0 -> c
@@ -750,7 +750,7 @@ defmodule EtherCAT.Slave do
 
     state_code =
       case Bus.transaction_queue(
-             data.link,
+             data.bus,
              &Transaction.fprd(&1, data.station, Registers.al_status())
            ) do
         {:ok, [%{data: <<_::3, _err::1, state::4, _::8>>, wkc: wkc}]} when wkc > 0 -> state
@@ -760,7 +760,7 @@ defmodule EtherCAT.Slave do
     ack_value = state_code + 0x10
 
     Bus.transaction_queue(
-      data.link,
+      data.bus,
       &Transaction.fpwr(&1, data.station, Registers.al_control(ack_value))
     )
 
@@ -769,11 +769,11 @@ defmodule EtherCAT.Slave do
 
   # -- SII -------------------------------------------------------------------
 
-  defp read_sii(link, station) do
-    with {:ok, identity} <- SII.read_identity(link, station),
-         {:ok, mailbox_config} <- SII.read_mailbox_config(link, station),
-         {:ok, sm_configs} <- SII.read_sm_configs(link, station),
-         {:ok, pdo_configs} <- SII.read_pdo_configs(link, station) do
+  defp read_sii(bus, station) do
+    with {:ok, identity} <- SII.read_identity(bus, station),
+         {:ok, mailbox_config} <- SII.read_mailbox_config(bus, station),
+         {:ok, sm_configs} <- SII.read_sm_configs(bus, station),
+         {:ok, pdo_configs} <- SII.read_pdo_configs(bus, station) do
       {:ok, identity, mailbox_config, sm_configs, pdo_configs}
     end
   end
@@ -810,7 +810,7 @@ defmodule EtherCAT.Slave do
     if function_exported?(data.driver, :sdo_config, 1) do
       Enum.each(data.driver.sdo_config(data.config), fn {index, subindex, value, size} ->
         case CoE.write_sdo(
-               data.link,
+               data.bus,
                data.station,
                data.mailbox_config,
                index,
@@ -858,7 +858,7 @@ defmodule EtherCAT.Slave do
         {active_latches, latch0_ctrl, latch1_ctrl} =
           build_latch_config(Map.get(dc_spec, :latches, []))
 
-        Bus.transaction_queue(data.link, fn tx ->
+        Bus.transaction_queue(data.bus, fn tx ->
           tx
           |> Transaction.fpwr(data.station, Registers.dc_sync0_cycle_time(cycle_ns))
           |> Transaction.fpwr(data.station, Registers.dc_sync1_cycle_time(sync1_cycle_ns))
@@ -954,7 +954,7 @@ defmodule EtherCAT.Slave do
     reg = latch_time_register(latch_id, edge)
 
     case Bus.transaction(
-           data.link,
+           data.bus,
            fn tx ->
              Transaction.fprd(tx, data.station, reg)
            end,
@@ -1005,7 +1005,7 @@ defmodule EtherCAT.Slave do
     sm0 = <<ro::16-little, rs::16-little, 0x26::8, 0::8, 0x00::8, 0::8>>
     sm1 = <<so::16-little, ss::16-little, 0x22::8, 0::8, 0x00::8, 0::8>>
 
-    Bus.transaction_queue(data.link, fn tx ->
+    Bus.transaction_queue(data.bus, fn tx ->
       tx
       |> Transaction.fpwr(data.station, Registers.sm_activate(0, 0))
       |> Transaction.fpwr(data.station, Registers.sm_activate(1, 0))

--- a/lib/ethercat/slave.md
+++ b/lib/ethercat/slave.md
@@ -69,7 +69,7 @@ via the `@paths` map. `walk_path/2` calls `do_transition/2` for each intermediat
 
 ```elixir
 %EtherCAT.Slave{
-  link:              pid(),              # Bus server reference
+  bus:               pid(),              # Bus server reference
   station:           non_neg_integer(),  # Configured station address (e.g. 0x1000)
   name:              atom(),             # Slave name atom
   driver:            module(),           # Module implementing EtherCAT.Slave.Driver (default: EtherCAT.Slave.Driver.Default)

--- a/lib/ethercat/slave/coe.ex
+++ b/lib/ethercat/slave/coe.ex
@@ -50,16 +50,16 @@ defmodule EtherCAT.Slave.CoE do
   """
   @spec write_sdo(pid(), non_neg_integer(), map(), integer(), integer(), integer(), 1 | 2 | 4) ::
           :ok | {:error, term()}
-  def write_sdo(link, station, mailbox_config, index, subindex, value, size) do
+  def write_sdo(bus, station, mailbox_config, index, subindex, value, size) do
     frame = build_request(index, subindex, value, size)
     # Mailbox SM0 only closes (signals PDI) when the last byte of recv_size is written.
     # Pad the frame to recv_size so SM0 fully closes and the slave processes the request.
     padded = frame <> :binary.copy(<<0>>, mailbox_config.recv_size - byte_size(frame))
 
-    with :ok <- write_mailbox(link, station, mailbox_config.recv_offset, padded),
-         :ok <- wait_response(link, station),
+    with :ok <- write_mailbox(bus, station, mailbox_config.recv_offset, padded),
+         :ok <- wait_response(bus, station),
          {:ok, response} <-
-           read_mailbox(link, station, mailbox_config.send_offset, mailbox_config.send_size) do
+           read_mailbox(bus, station, mailbox_config.send_offset, mailbox_config.send_size) do
       validate_response(response, index, subindex)
     end
   end
@@ -86,20 +86,20 @@ defmodule EtherCAT.Slave.CoE do
 
   # -- Transport helpers -------------------------------------------------------
 
-  defp write_mailbox(link, station, recv_offset, frame) do
-    case Bus.transaction_queue(link, &Transaction.fpwr(&1, station, {recv_offset, frame})) do
+  defp write_mailbox(bus, station, recv_offset, frame) do
+    case Bus.transaction_queue(bus, &Transaction.fpwr(&1, station, {recv_offset, frame})) do
       {:ok, [%{wkc: wkc}]} when wkc > 0 -> :ok
       {:ok, [%{wkc: 0}]} -> {:error, :no_response}
       {:error, _} = err -> err
     end
   end
 
-  defp wait_response(link, station), do: wait_response(link, station, @poll_limit)
+  defp wait_response(bus, station), do: wait_response(bus, station, @poll_limit)
 
-  defp wait_response(_link, _station, 0), do: {:error, :response_timeout}
+  defp wait_response(_bus, _station, 0), do: {:error, :response_timeout}
 
-  defp wait_response(link, station, remaining) do
-    case Bus.transaction_queue(link, &Transaction.fprd(&1, station, Registers.sm_status(1))) do
+  defp wait_response(bus, station, remaining) do
+    case Bus.transaction_queue(bus, &Transaction.fprd(&1, station, Registers.sm_status(1))) do
       {:ok, [%{data: <<status::8>>, wkc: wkc}]} when wkc > 0 ->
         case <<status::8>> do
           <<_::4, 1::1, _::3>> ->
@@ -108,7 +108,7 @@ defmodule EtherCAT.Slave.CoE do
 
           _ ->
             Process.sleep(@poll_interval_ms)
-            wait_response(link, station, remaining - 1)
+            wait_response(bus, station, remaining - 1)
         end
 
       {:ok, [%{wkc: 0}]} ->
@@ -119,8 +119,8 @@ defmodule EtherCAT.Slave.CoE do
     end
   end
 
-  defp read_mailbox(link, station, send_offset, send_size) do
-    case Bus.transaction_queue(link, &Transaction.fprd(&1, station, {send_offset, send_size})) do
+  defp read_mailbox(bus, station, send_offset, send_size) do
+    case Bus.transaction_queue(bus, &Transaction.fprd(&1, station, {send_offset, send_size})) do
       {:ok, [%{data: data, wkc: wkc}]} when wkc > 0 -> {:ok, data}
       {:ok, [%{wkc: 0}]} -> {:error, :no_response}
       {:error, _} = err -> err

--- a/lib/ethercat/slave/registers.ex
+++ b/lib/ethercat/slave/registers.ex
@@ -6,7 +6,7 @@ defmodule EtherCAT.Slave.Registers do
   sites never need to hard-code a size separately:
 
       {addr, size} = Registers.al_status()
-      Link.transaction(link, &Transaction.fprd(&1, station, addr, size))
+      Bus.transaction_queue(bus, &Transaction.fprd(&1, station, {addr, size}))
 
   Registers whose size is determined at runtime return a bare address integer.
   Array-indexed registers (SyncManager, FMMU) provide a base-offset function

--- a/lib/ethercat/slave/sii.ex
+++ b/lib/ethercat/slave/sii.ex
@@ -13,13 +13,13 @@ defmodule EtherCAT.Slave.SII do
       alias EtherCAT.Slave.SII
 
       # Read vendor ID (words 0x08–0x09)
-      {:ok, <<vendor_id::32-little>>} = SII.read(link, 0x1000, 0x08, 2)
+      {:ok, <<vendor_id::32-little>>} = SII.read(bus, 0x1000, 0x08, 2)
 
       # Write configured station alias (word 0x04)
-      :ok = SII.write(link, 0x1000, 0x04, <<0x00, 0x10>>)
+      :ok = SII.write(bus, 0x1000, 0x04, <<0x00, 0x10>>)
 
       # Reload ESC configuration from EEPROM
-      :ok = SII.reload(link, 0x1000)
+      :ok = SII.reload(bus, 0x1000)
   """
 
   alias EtherCAT.Bus
@@ -63,9 +63,9 @@ defmodule EtherCAT.Slave.SII do
              serial_number: integer()
            }}
           | {:error, atom()}
-  def read_identity(link, station) do
+  def read_identity(bus, station) do
     with {:ok, <<vid::32-little, pc::32-little, rev::32-little, sn::32-little>>} <-
-           read(link, station, 0x08, 8) do
+           read(bus, station, 0x08, 8) do
       {:ok, %{vendor_id: vid, product_code: pc, revision: rev, serial_number: sn}}
     end
   end
@@ -88,9 +88,9 @@ defmodule EtherCAT.Slave.SII do
              send_size: integer()
            }}
           | {:error, atom()}
-  def read_mailbox_config(link, station) do
+  def read_mailbox_config(bus, station) do
     with {:ok, <<ro::16-little, rs::16-little, so::16-little, ss::16-little>>} <-
-           read(link, station, 0x18, 4) do
+           read(bus, station, 0x18, 4) do
       {:ok, %{recv_offset: ro, recv_size: rs, send_offset: so, send_size: ss}}
     end
   end
@@ -121,7 +121,7 @@ defmodule EtherCAT.Slave.SII do
   matching the `DefaultSize` and `ControlRegister` shown by `ethercat pdos`.
   """
   @spec read_sm_configs(pid(), non_neg_integer()) :: {:ok, [sm_entry()]} | {:error, atom()}
-  def read_sm_configs(link, station), do: find_sm_category(link, station, @category_start)
+  def read_sm_configs(bus, station), do: find_sm_category(bus, station, @category_start)
 
   @doc """
   Read TxPDO (0x0032) and RxPDO (0x0033) category data from SII EEPROM.
@@ -133,8 +133,8 @@ defmodule EtherCAT.Slave.SII do
   Returns `{:ok, []}` if no PDO categories are present.
   """
   @spec read_pdo_configs(pid(), non_neg_integer()) :: {:ok, [pdo_config()]} | {:error, atom()}
-  def read_pdo_configs(link, station),
-    do: find_pdo_categories(link, station, @category_start, [])
+  def read_pdo_configs(bus, station),
+    do: find_pdo_categories(bus, station, @category_start, [])
 
   @doc """
   Read the valid SII contents by walking the category structure.
@@ -145,9 +145,9 @@ defmodule EtherCAT.Slave.SII do
   Returns `{:ok, binary}` or `{:error, reason}`.
   """
   @spec dump(pid(), non_neg_integer()) :: {:ok, binary()} | {:error, atom()}
-  def dump(link, station) do
-    with {:ok, end_word} <- find_end(link, station) do
-      read(link, station, 0x0000, end_word)
+  def dump(bus, station) do
+    with {:ok, end_word} <- find_end(bus, station) do
+      read(bus, station, 0x0000, end_word)
     end
   end
 
@@ -158,9 +158,9 @@ defmodule EtherCAT.Slave.SII do
   """
   @spec read(pid(), non_neg_integer(), non_neg_integer(), pos_integer()) ::
           {:ok, binary()} | {:error, atom()}
-  def read(link, station, word_address, word_count) do
-    with {:ok, chunk_words} <- read_data_register_size(link, station) do
-      read_chunks(link, station, word_address, word_count, chunk_words, [])
+  def read(bus, station, word_address, word_count) do
+    with {:ok, chunk_words} <- read_data_register_size(bus, station) do
+      read_chunks(bus, station, word_address, word_count, chunk_words, [])
     end
   end
 
@@ -174,8 +174,8 @@ defmodule EtherCAT.Slave.SII do
   """
   @spec write(pid(), non_neg_integer(), non_neg_integer(), binary()) ::
           :ok | {:error, atom()}
-  def write(link, station, word_address, data) when rem(byte_size(data), 2) == 0 do
-    write_words(link, station, word_address, data)
+  def write(bus, station, word_address, data) when rem(byte_size(data), 2) == 0 do
+    write_words(bus, station, word_address, data)
   end
 
   @doc """
@@ -188,11 +188,11 @@ defmodule EtherCAT.Slave.SII do
   Returns `:ok` or `{:error, reason}`.
   """
   @spec reload(pid(), non_neg_integer()) :: :ok | {:error, atom()}
-  def reload(link, station) do
-    with :ok <- ensure_ready(link, station),
-         :ok <- write_reg(link, station, Registers.eeprom_control(), @cmd_reload),
-         :ok <- wait_busy(link, station) do
-      check_errors(link, station)
+  def reload(bus, station) do
+    with :ok <- ensure_ready(bus, station),
+         :ok <- write_reg(bus, station, Registers.eeprom_control(), @cmd_reload),
+         :ok <- wait_busy(bus, station) do
+      check_errors(bus, station)
     end
   end
 
@@ -200,18 +200,18 @@ defmodule EtherCAT.Slave.SII do
 
   # Walk SII categories from @category_start to find type 0x0029 (SyncManager).
   # Category header: [type::16-little, size::16-little] (size in WORDS = size*2 bytes of data)
-  defp find_sm_category(link, station, addr) do
-    case read(link, station, addr, 2) do
+  defp find_sm_category(bus, station, addr) do
+    case read(bus, station, addr, 2) do
       {:ok, <<0xFFFF::16-little, _::16>>} ->
         {:ok, []}
 
       {:ok, <<0x0029::16-little, size::16-little>>} ->
-        with {:ok, data} <- read(link, station, addr + 2, size) do
+        with {:ok, data} <- read(bus, station, addr + 2, size) do
           {:ok, parse_sm_entries(data, 0, [])}
         end
 
       {:ok, <<_type::16-little, size::16-little>>} ->
-        find_sm_category(link, station, addr + 2 + size)
+        find_sm_category(bus, station, addr + 2 + size)
 
       {:error, _} = err ->
         err
@@ -234,21 +234,21 @@ defmodule EtherCAT.Slave.SII do
   # -- PDO category reading (0x0032 TxPDO=input, 0x0033 RxPDO=output) --------
 
   # Walk all categories; collect 0x0032 and 0x0033 entries.
-  defp find_pdo_categories(link, station, addr, acc) do
-    case read(link, station, addr, 2) do
+  defp find_pdo_categories(bus, station, addr, acc) do
+    case read(bus, station, addr, 2) do
       {:ok, <<0xFFFF::16-little, _::16>>} ->
         {:ok, assign_bit_offsets(acc)}
 
       {:ok, <<cat::16-little, size::16-little>>} when cat in [0x0032, 0x0033] ->
         dir = if cat == 0x0032, do: :input, else: :output
 
-        with {:ok, data} <- read(link, station, addr + 2, size) do
+        with {:ok, data} <- read(bus, station, addr + 2, size) do
           pdos = parse_pdo_category(data, dir, [])
-          find_pdo_categories(link, station, addr + 2 + size, acc ++ pdos)
+          find_pdo_categories(bus, station, addr + 2 + size, acc ++ pdos)
         end
 
       {:ok, <<_::16, size::16-little>>} ->
-        find_pdo_categories(link, station, addr + 2 + size, acc)
+        find_pdo_categories(bus, station, addr + 2 + size, acc)
 
       {:error, _} = err ->
         err
@@ -300,16 +300,16 @@ defmodule EtherCAT.Slave.SII do
   # Walk category headers from word 0x40 to find the end of valid SII data.
   # Each category: [type::16-little, size::16-little, data::size*2 bytes]
   # End marker: type == 0xFFFF
-  defp find_end(link, station), do: find_end(link, station, @category_start)
+  defp find_end(bus, station), do: find_end(bus, station, @category_start)
 
-  defp find_end(link, station, addr) do
-    case read(link, station, addr, 2) do
+  defp find_end(bus, station, addr) do
+    case read(bus, station, addr, 2) do
       {:ok, <<0xFFFF::16-little, _::16>>} ->
         # End marker — include it in the dump
         {:ok, addr + 1}
 
       {:ok, <<_type::16-little, size::16-little>>} ->
-        find_end(link, station, addr + 2 + size)
+        find_end(bus, station, addr + 2 + size)
 
       {:error, _} = err ->
         err
@@ -320,13 +320,13 @@ defmodule EtherCAT.Slave.SII do
     {:ok, :erlang.iolist_to_binary(Enum.reverse(acc))}
   end
 
-  defp read_chunks(link, station, addr, remaining, chunk_words, acc) do
-    with {:ok, chunk_data} <- read_one(link, station, addr, chunk_words) do
+  defp read_chunks(bus, station, addr, remaining, chunk_words, acc) do
+    with {:ok, chunk_data} <- read_one(bus, station, addr, chunk_words) do
       take = min(remaining, chunk_words)
       <<used::binary-size(take * 2), _::binary>> = chunk_data
 
       read_chunks(
-        link,
+        bus,
         station,
         addr + chunk_words,
         remaining - take,
@@ -336,15 +336,15 @@ defmodule EtherCAT.Slave.SII do
     end
   end
 
-  defp read_one(link, station, word_address, chunk_words) do
+  defp read_one(bus, station, word_address, chunk_words) do
     retry_on_ack(@max_ack_retries, fn ->
-      with :ok <- ensure_ready(link, station),
+      with :ok <- ensure_ready(bus, station),
            :ok <-
-             write_reg(link, station, Registers.eeprom_address(), <<word_address::32-little>>),
-           :ok <- write_reg(link, station, Registers.eeprom_control(), @cmd_read),
-           :ok <- wait_busy(link, station),
-           :ok <- check_errors(link, station) do
-        read_reg(link, station, {Registers.eeprom_data(), chunk_words * 2})
+             write_reg(bus, station, Registers.eeprom_address(), <<word_address::32-little>>),
+           :ok <- write_reg(bus, station, Registers.eeprom_control(), @cmd_read),
+           :ok <- wait_busy(bus, station),
+           :ok <- check_errors(bus, station) do
+        read_reg(bus, station, {Registers.eeprom_data(), chunk_words * 2})
       end
     end)
   end
@@ -353,57 +353,57 @@ defmodule EtherCAT.Slave.SII do
 
   defp write_words(_link, _station, _addr, <<>>), do: :ok
 
-  defp write_words(link, station, addr, <<word::binary-size(2), rest::binary>>) do
-    with :ok <- write_one(link, station, addr, word) do
-      write_words(link, station, addr + 1, rest)
+  defp write_words(bus, station, addr, <<word::binary-size(2), rest::binary>>) do
+    with :ok <- write_one(bus, station, addr, word) do
+      write_words(bus, station, addr + 1, rest)
     end
   end
 
-  defp write_one(link, station, word_address, <<_::binary-size(2)>> = word) do
+  defp write_one(bus, station, word_address, <<_::binary-size(2)>> = word) do
     retry_on_ack(@max_ack_retries, fn ->
-      with :ok <- ensure_ready(link, station),
+      with :ok <- ensure_ready(bus, station),
            :ok <-
-             write_reg(link, station, Registers.eeprom_address(), <<word_address::32-little>>),
-           :ok <- write_reg(link, station, {Registers.eeprom_data(), 2}, word),
+             write_reg(bus, station, Registers.eeprom_address(), <<word_address::32-little>>),
+           :ok <- write_reg(bus, station, {Registers.eeprom_data(), 2}, word),
            # Write-enable (bit 0) + write command (bits 10:8) in the same frame
-           :ok <- write_reg(link, station, Registers.eeprom_control(), @cmd_write),
-           :ok <- wait_busy(link, station) do
-        check_errors(link, station)
+           :ok <- write_reg(bus, station, Registers.eeprom_control(), @cmd_write),
+           :ok <- wait_busy(bus, station) do
+        check_errors(bus, station)
       end
     end)
   end
 
   # -- Protocol helpers -------------------------------------------------------
 
-  defp ensure_ready(link, station) do
-    with :ok <- wait_busy(link, station) do
-      clear_errors_if_needed(link, station)
+  defp ensure_ready(bus, station) do
+    with :ok <- wait_busy(bus, station) do
+      clear_errors_if_needed(bus, station)
     end
   end
 
-  defp wait_busy(link, station), do: wait_busy(link, station, @busy_poll_limit)
+  defp wait_busy(bus, station), do: wait_busy(bus, station, @busy_poll_limit)
 
   defp wait_busy(_link, _station, 0), do: {:error, :busy_timeout}
 
-  defp wait_busy(link, station, remaining) do
-    case read_reg(link, station, Registers.eeprom_control()) do
+  defp wait_busy(bus, station, remaining) do
+    case read_reg(bus, station, Registers.eeprom_control()) do
       {:ok, <<_lo, busy::1, _::7>>} when busy == 0 ->
         :ok
 
       {:ok, _} ->
         Process.sleep(@busy_poll_interval_ms)
-        wait_busy(link, station, remaining - 1)
+        wait_busy(bus, station, remaining - 1)
 
       {:error, _} = err ->
         err
     end
   end
 
-  defp clear_errors_if_needed(link, station) do
-    case read_reg(link, station, Registers.eeprom_control()) do
+  defp clear_errors_if_needed(bus, station) do
+    case read_reg(bus, station, Registers.eeprom_control()) do
       {:ok, <<_lo, hi::binary-size(1)>>} ->
         if has_errors?(hi) do
-          write_reg(link, station, Registers.eeprom_control(), @cmd_nop)
+          write_reg(bus, station, Registers.eeprom_control(), @cmd_nop)
         else
           :ok
         end
@@ -413,8 +413,8 @@ defmodule EtherCAT.Slave.SII do
     end
   end
 
-  defp check_errors(link, station) do
-    case read_reg(link, station, Registers.eeprom_control()) do
+  defp check_errors(bus, station) do
+    case read_reg(bus, station, Registers.eeprom_control()) do
       {:ok, <<_lo, hi::binary-size(1)>>} -> check_error_bits(hi)
       {:error, _} = err -> err
     end
@@ -458,8 +458,8 @@ defmodule EtherCAT.Slave.SII do
 
   # Data register size: bit 6 of control/status.
   # 0 = 4 bytes (2 words), 1 = 8 bytes (4 words)
-  defp read_data_register_size(link, station) do
-    case read_reg(link, station, Registers.eeprom_control()) do
+  defp read_data_register_size(bus, station) do
+    case read_reg(bus, station, Registers.eeprom_control()) do
       {:ok, <<_lo_rest::7, size_bit::1, _hi>>} ->
         if size_bit == 1, do: {:ok, 4}, else: {:ok, 2}
 
@@ -470,16 +470,16 @@ defmodule EtherCAT.Slave.SII do
 
   # -- Register I/O -----------------------------------------------------------
 
-  defp read_reg(link, station, {_addr, _size} = reg) do
-    case Bus.transaction_queue(link, &Transaction.fprd(&1, station, reg)) do
+  defp read_reg(bus, station, {_addr, _size} = reg) do
+    case Bus.transaction_queue(bus, &Transaction.fprd(&1, station, reg)) do
       {:ok, [%{data: data, wkc: wkc}]} when wkc > 0 -> {:ok, data}
       {:ok, [%{wkc: 0}]} -> {:error, :no_response}
       {:error, _} = err -> err
     end
   end
 
-  defp write_reg(link, station, {addr, _size}, data) do
-    case Bus.transaction_queue(link, &Transaction.fpwr(&1, station, {addr, data})) do
+  defp write_reg(bus, station, {addr, _size}, data) do
+    case Bus.transaction_queue(bus, &Transaction.fpwr(&1, station, {addr, data})) do
       {:ok, [%{wkc: wkc}]} when wkc > 0 -> :ok
       {:ok, [%{wkc: 0}]} -> {:error, :no_response}
       {:error, _} = err -> err

--- a/test/ethercat/domain_test.exs
+++ b/test/ethercat/domain_test.exs
@@ -8,7 +8,7 @@ defmodule EtherCAT.DomainTest do
 
     {:ok, _pid} =
       start_supervised(
-        {Domain, [id: domain_id, link: self(), period: 60_000, miss_threshold: 500]}
+        {Domain, [id: domain_id, bus: self(), period: 60_000, miss_threshold: 500]}
       )
 
     %{domain_id: domain_id}


### PR DESCRIPTION
# Summary

Fixes SID-20 by preserving the LRW WKC readiness fix and applying rework feedback that removes stale `domain_pids` tracking and standardizes bus process naming (`link` -> `bus`) across runtime modules.

## Changes

- Kept the previously merged SID-20 LRW WKC fix path intact (regression still covered and passing).
- Removed `domain_pids` from `EtherCAT.Master` state and switched session teardown to resolve domain processes via `Registry.lookup({:domain, id})` from configured domain ids.
- Renamed bus pid option/field usage from `link` to `bus` across `Master`, `Domain`, `Slave`, and `DC` startup/runtime paths.
- Updated `Slave` helper modules (`SII`, `CoE`) to use `bus` naming for consistency.
- Updated affected docs/tests (`master.md`, `domain.md`, `slave.md`, `domain_test.exs`) and cleaned stale naming examples in `slave/registers.ex` docs.

## Motivation

SID-20: https://linear.app/sid2baker/issue/SID-20/fix-ethercatread-inputsensor-ch1-error-not-ready

Rework feedback requested two follow-ups after the initial fix:
1. Remove `domain_pids` retention in master.
2. Eliminate lingering `link` naming for bus references.

## Validation

- [x] `mix compile --warnings-as-errors`
- [x] `mix test`

## Notes

This is an API naming cleanup in a pre-release codebase, so `:link` start options for `Domain`/`Slave`/`DC` were intentionally replaced by `:bus` without compatibility shims.
