### PR TITLE
Filter shared-SM subscribe events by PDO change

### DIFF
--- a/lib/ethercat/domain.ex
+++ b/lib/ethercat/domain.ex
@@ -34,8 +34,8 @@ defmodule EtherCAT.Domain do
 
   ## Input change notifications
 
-  The Domain sends `{:domain_input, domain_id, key, raw_binary}` to the
-  registered slave pid whenever an input value changes after a cycle.
+  The Domain sends `{:domain_input, domain_id, key, old_raw_binary | :unset, new_raw_binary}`
+  to the registered slave pid whenever an input value changes after a cycle.
   Slaves decode and re-publish to application subscribers.
 
   ## ETS table schema
@@ -410,7 +410,7 @@ defmodule EtherCAT.Domain do
 
       if new_val != old_val do
         :ets.update_element(table, key, {2, new_val})
-        send(slave_pid, {:domain_input, domain_id, key, new_val})
+        send(slave_pid, {:domain_input, domain_id, key, old_val, new_val})
       end
     end)
   end

--- a/lib/ethercat/domain.md
+++ b/lib/ethercat/domain.md
@@ -59,8 +59,8 @@ rounded up). On each `:tick`:
    output values from ETS into a zero-filled frame without intermediate allocation.
 2. **LRW transaction** (`Bus.transaction/3`): sends the frame with a timeout budget slightly below cycle period; stale ticks are dropped.
 3. **Dispatch inputs** (`dispatch_inputs/4`): for each input slice, compares new value
-   against ETS; on change, updates ETS and sends `{:domain_input, domain_id, key, raw}` to
-   the slave pid.
+   against ETS; on change, updates ETS and sends
+   `{:domain_input, domain_id, key, old_raw | :unset, new_raw}` to the slave pid.
 4. **Schedule next tick**: uses `next_cycle_at + period_us` drift-compensated schedule
    (not `now + period_us`) to prevent period drift accumulation.
 

--- a/lib/ethercat/slave.ex
+++ b/lib/ethercat/slave.ex
@@ -110,8 +110,6 @@ defmodule EtherCAT.Slave do
     :pdo_registrations,
     # %{pdo_name => [pid]}
     :pdo_subscriptions,
-    # %{pdo_name => raw_input_binary} used to emit change notifications per PDO
-    pdo_last_inputs: %{},
     # %{{latch_id, edge} => [pid]}
     latch_subscriptions: %{}
   ]
@@ -229,7 +227,6 @@ defmodule EtherCAT.Slave do
       latch_poll_ms: nil,
       pdo_registrations: %{},
       pdo_subscriptions: %{},
-      pdo_last_inputs: %{},
       latch_subscriptions: %{}
     }
 
@@ -395,45 +392,39 @@ defmodule EtherCAT.Slave do
   # SM-grouped key: {slave_name, {:sm, idx}} — unpack per-PDO bits and dispatch.
   def handle_event(
         :info,
-        {:domain_input, _domain_id, {_slave_name, {:sm, _} = sm_key}, sm_bytes},
+        {:domain_input, _domain_id, {_slave_name, {:sm, _} = sm_key}, old_sm_bytes, new_sm_bytes},
         _state,
         data
       ) do
-    {new_pdo_last_inputs, notifications} =
+    notifications =
       data.pdo_registrations
       |> Enum.filter(fn {_pdo_name, reg} -> reg.sm_key == sm_key end)
-      |> Enum.reduce({data.pdo_last_inputs, []}, fn
-        {pdo_name, %{bit_offset: bit_offset, bit_size: bit_size}}, {pdo_last_inputs, acc} ->
-          raw = extract_sm_bits(sm_bytes, bit_offset, bit_size)
+      |> Enum.reduce([], fn {pdo_name, %{bit_offset: bit_offset, bit_size: bit_size}}, acc ->
+        if pdo_changed?(old_sm_bytes, new_sm_bytes, bit_offset, bit_size) do
+          raw = extract_sm_bits(new_sm_bytes, bit_offset, bit_size)
 
-          case Map.get(pdo_last_inputs, pdo_name) do
-            ^raw ->
-              {pdo_last_inputs, acc}
+          decoded =
+            if data.driver != nil do
+              data.driver.decode_inputs(pdo_name, data.config, raw)
+            else
+              raw
+            end
 
-            _prev_raw ->
-              decoded =
-                if data.driver != nil do
-                  data.driver.decode_inputs(pdo_name, data.config, raw)
-                else
-                  raw
-                end
-
-              next_acc =
-                data.pdo_subscriptions
-                |> Map.get(pdo_name, [])
-                |> Enum.reduce(acc, fn pid, pid_acc ->
-                  [{pid, pdo_name, decoded} | pid_acc]
-                end)
-
-              {Map.put(pdo_last_inputs, pdo_name, raw), next_acc}
-          end
+          data.pdo_subscriptions
+          |> Map.get(pdo_name, [])
+          |> Enum.reduce(acc, fn pid, pid_acc ->
+            [{pid, pdo_name, decoded} | pid_acc]
+          end)
+        else
+          acc
+        end
       end)
 
     Enum.each(Enum.reverse(notifications), fn {pid, pdo_name, decoded} ->
       send(pid, {:slave_input, data.name, pdo_name, decoded})
     end)
 
-    {:keep_state, %{data | pdo_last_inputs: new_pdo_last_inputs}}
+    :keep_state_and_data
   end
 
   def handle_event(:state_timeout, :latch_poll, :op, data) do
@@ -1061,6 +1052,13 @@ defmodule EtherCAT.Slave do
 
       <<encoded_value::unsigned-little-size(encoded_bits)>>
     end
+  end
+
+  defp pdo_changed?(:unset, _new_sm_bytes, _bit_offset, _bit_size), do: true
+
+  defp pdo_changed?(old_sm_bytes, new_sm_bytes, bit_offset, bit_size) do
+    extract_sm_bits(old_sm_bytes, bit_offset, bit_size) !=
+      extract_sm_bits(new_sm_bytes, bit_offset, bit_size)
   end
 
   # Write `bit_size` bits from `encoded` into `sm_bytes` at `bit_offset`.

--- a/test/ethercat/slave_test.exs
+++ b/test/ethercat/slave_test.exs
@@ -26,14 +26,13 @@ defmodule EtherCAT.SlaveTest do
         ch1: %{sm_key: {:sm, 0}, bit_offset: 0, bit_size: 1},
         ch2: %{sm_key: {:sm, 0}, bit_offset: 1, bit_size: 1}
       },
-      pdo_subscriptions: %{ch1: [self()], ch2: [self()]},
-      pdo_last_inputs: %{}
+      pdo_subscriptions: %{ch1: [self()], ch2: [self()]}
     }
 
-    assert {:keep_state, data_after_initial} =
+    assert :keep_state_and_data =
              EtherCAT.Slave.handle_event(
                :info,
-               {:domain_input, :main, {:sensor, {:sm, 0}}, <<0>>},
+               {:domain_input, :main, {:sensor, {:sm, 0}}, :unset, <<0>>},
                :op,
                data
              )
@@ -42,34 +41,34 @@ defmodule EtherCAT.SlaveTest do
     assert_receive {:slave_input, :sensor, :ch2, 0}
     refute_receive _
 
-    assert {:keep_state, data_after_ch2} =
+    assert :keep_state_and_data =
              EtherCAT.Slave.handle_event(
                :info,
-               {:domain_input, :main, {:sensor, {:sm, 0}}, <<2>>},
+               {:domain_input, :main, {:sensor, {:sm, 0}}, <<0>>, <<2>>},
                :op,
-               data_after_initial
+               data
              )
 
     assert_receive {:slave_input, :sensor, :ch2, 1}
     refute_receive {:slave_input, :sensor, :ch1, _}
     refute_receive _
 
-    assert {:keep_state, _data_after_repeat} =
+    assert :keep_state_and_data =
              EtherCAT.Slave.handle_event(
                :info,
-               {:domain_input, :main, {:sensor, {:sm, 0}}, <<2>>},
+               {:domain_input, :main, {:sensor, {:sm, 0}}, <<2>>, <<2>>},
                :op,
-               data_after_ch2
+               data
              )
 
     refute_receive _
 
-    assert {:keep_state, _data_after_ch1} =
+    assert :keep_state_and_data =
              EtherCAT.Slave.handle_event(
                :info,
-               {:domain_input, :main, {:sensor, {:sm, 0}}, <<3>>},
+               {:domain_input, :main, {:sensor, {:sm, 0}}, <<2>>, <<3>>},
                :op,
-               data_after_ch2
+               data
              )
 
     assert_receive {:slave_input, :sensor, :ch1, 1}


### PR DESCRIPTION
# Summary
This PR fixes `EtherCAT.subscribe/3` false positives for PDOs that share one SyncManager by filtering notifications from per-event SM deltas (`old` vs `new`) instead of replaying all PDOs when any SM byte changes.

## Changes
- Changed internal domain-to-slave input event payload to include both previous and current raw bytes: `{:domain_input, domain_id, key, old_raw | :unset, new_raw}`.
- Simplified `EtherCAT.Slave` shared-SM notification logic to compare each PDO bit slice between old/new SM payloads and emit only for changed PDOs.
- Removed the persistent `pdo_last_inputs` cache from slave state.
- Updated `lib/ethercat/domain.md` documentation for the internal event contract.
- Updated regression coverage in `test/ethercat/slave_test.exs` to validate first-sample dispatch, same-PDO change dispatch, and no cross-PDO notifications.

## Motivation
`EtherCAT.subscribe(slave, pdo)` emitted `{:slave_input, ...}` for all PDOs in an SM when any PDO in that SM changed. This produced noisy updates like `:ch1` notifications when only `:ch2` changed.

Linear ticket: https://linear.app/sid2baker/issue/SID-21/ethercatsubscribe-triggers-when-any-sm-is-changed

## Validation
- [x] `mix compile --warnings-as-errors`
- [x] `mix test`

## Notes
The implementation remains aligned with the current SM-grouped registration/FMMU model while making per-PDO subscriptions precise.
